### PR TITLE
Release pyodide-lock.json separately

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,6 +198,7 @@ jobs:
         with:
           files: |
             ./packages.tar.gz
+            ./repodata/pyodide-lock.json
 
   test:
     runs-on: ubuntu-latest

--- a/packages/pyarrow/test_pyarrow.py
+++ b/packages/pyarrow/test_pyarrow.py
@@ -1,6 +1,8 @@
+import pytest
 from pytest_pyodide import run_in_pyodide
 
 
+@pytest.mark.driver_timeout(120)
 @run_in_pyodide(packages=["pyarrow", "numpy", "pandas"])
 def test_read_write_parquet(selenium):
     import numpy as np

--- a/packages/scikit-learn/meta.yaml
+++ b/packages/scikit-learn/meta.yaml
@@ -1,13 +1,13 @@
 package:
   name: scikit-learn
-  version: 1.5.0
+  version: 1.5.1
   tag:
     - min-scipy-stack
   top-level:
     - sklearn
 source:
-  url: https://files.pythonhosted.org/packages/bf/8a/06e499bca463905000f50e461c9445e949aafdd33ea3b62024aa2238b83d/scikit_learn-1.5.0.tar.gz
-  sha256: 789e3db01c750ed6d496fa2db7d50637857b451e57bcae863bff707c1247bef7
+  url: https://files.pythonhosted.org/packages/92/72/2961b9874a9ddf2b0f95f329d4e67f67c3301c1d88ba5e239ff25661bb85/scikit_learn-1.5.1.tar.gz
+  sha256: 0ea5d40c0e3951df445721927448755d3fe1d80833b0b7308ebff5d2a45e6414
 
 build:
   cflags: -Wno-implicit-function-declaration

--- a/packages/scipy/meta.yaml
+++ b/packages/scipy/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: scipy
-  version: 1.13.1
+  version: 1.14.0
   tag:
     - min-scipy-stack
   top-level:
@@ -17,25 +17,27 @@ package:
 # subroutine. Try deleting it.
 
 source:
-  url: https://files.pythonhosted.org/packages/ae/00/48c2f661e2816ccf2ecd77982f6605b2950afe60f60a52b4cbbc2504aa8f/scipy-1.13.1.tar.gz
-  sha256: 095a87a0312b08dfd6a6155cbbd310a8c51800fc931b8c0b84003014b874ed3c
+  url: https://files.pythonhosted.org/packages/4e/e5/0230da034a2e1b1feb32621d7cd57c59484091d6dccc9e6b855b0d309fc9/scipy-1.14.0.tar.gz
+  sha256: b5923f48cb840380f9854339176ef21763118a7300a88203ccd0bdd26e58527b
 
   patches:
     - patches/0001-Fix-dstevr-in-special-lapack_defs.h.patch
     - patches/0002-int-to-string.patch
     - patches/0003-gemm_-no-const.patch
     - patches/0004-make-int-return-values.patch
-    - patches/0005-Remove-test-modules-that-fails-to-build.patch
-    - patches/0006-Fix-fitpack.patch
-    - patches/0007-Fix-gees-calls.patch
-    - patches/0008-MAINT-linalg-Remove-id_dist-Fortran-files.patch
-    - patches/0009-Mark-mvndst-functions-recursive.patch
-    - patches/0010-Make-sreorth-recursive.patch
-    - patches/0011-Link-openblas-with-modules-that-require-f2c.patch
-    - patches/0012-Remove-fpchec-inline-if-else-constructs.patch
-    - patches/0013-Remove-chla_transtype.patch
-    - patches/0014-Set-wrapper-return-type-to-int.patch
-    - patches/0015-Skip-svd_gesdd-test.patch
+    - patches/0005-Fix-fitpack.patch
+    - patches/0006-Fix-gees-calls.patch
+    - patches/0007-MAINT-linalg-Remove-id_dist-Fortran-files.patch
+    - patches/0008-Mark-mvndst-functions-recursive.patch
+    - patches/0009-Make-sreorth-recursive.patch
+    - patches/0010-Link-openblas-with-modules-that-require-f2c.patch
+    - patches/0011-Remove-fpchec-inline-if-then-endif-constructs.patch # remove with SciPy v1.15.0
+    - patches/0012-Remove-chla_transtype.patch
+    - patches/0013-Set-wrapper-return-type-to-int.patch
+    - patches/0014-Skip-svd_gesdd-test.patch # remove with SciPy v1.15.0
+    - patches/0015-Remove-f2py-generator.patch
+    - patches/0016-Make-sf_error_state_lib-a-static-library.patch
+    - patches/0017-Remove-test-modules-that-fail-to-build.patch
 
 build:
   cflags: |
@@ -50,8 +52,14 @@ build:
     -L$(NUMPY_LIB)/core/lib/
     -L$(NUMPY_LIB)/random/lib/
     -fexceptions
+
+  # Exclude tests via Meson's install tags functionality.
+  unvendor-tests: true
+  # install-args=--tags=runtime,python-runtime,devel
+  # Disable when running tests, enable when a PR is ready, i.e., building for distribution.
   backend-flags: |
     build-dir=build
+
   # IMPORTANT: Other locations important in scipy build process:
   # There are two files built in the "capture" pass that need patching:
   #    _blas_subroutines.h, and _cython

--- a/packages/scipy/patches/0001-Fix-dstevr-in-special-lapack_defs.h.patch
+++ b/packages/scipy/patches/0001-Fix-dstevr-in-special-lapack_defs.h.patch
@@ -1,7 +1,7 @@
 From 45a31145679c83f2719b6420f234d484b9459697 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Fri, 18 Mar 2022 16:25:39 -0700
-Subject: [PATCH 1/15] Fix dstevr in special/lapack_defs.h
+Subject: [PATCH 1/17] Fix dstevr in special/lapack_defs.h
 
 ---
  scipy/special/lapack_defs.h | 5 ++---

--- a/packages/scipy/patches/0002-int-to-string.patch
+++ b/packages/scipy/patches/0002-int-to-string.patch
@@ -1,7 +1,7 @@
 From d53ade3f03ba3557fd50fb38990d605f4ae7f8f1 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Sat, 25 Dec 2021 18:04:18 -0800
-Subject: [PATCH 2/15] int to string
+Subject: [PATCH 2/17] int to string
 
 f2c does not handle implicit casts of function arguments correctly. The msg
 argument of `xerrwv` is defined to be an `int *`, and then implicitly cast

--- a/packages/scipy/patches/0003-gemm_-no-const.patch
+++ b/packages/scipy/patches/0003-gemm_-no-const.patch
@@ -1,7 +1,7 @@
 From e528227dd37c8b0512381992c222789a114e3169 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Sat, 18 Dec 2021 11:41:15 -0800
-Subject: [PATCH 3/15] gemm_ no const
+Subject: [PATCH 3/17] gemm_ no const
 
 cgemm, dgemm, sgemm, and zgemm are declared with `const` in slu_cdefs.h, but
 other places don't have the cosnt causing compile errors.

--- a/packages/scipy/patches/0004-make-int-return-values.patch
+++ b/packages/scipy/patches/0004-make-int-return-values.patch
@@ -1,7 +1,7 @@
 From a86a2304fd925f815bbb0e0753e46a7b863e2de2 Mon Sep 17 00:00:00 2001
 From: Joe Marshall <joe.marshall@nottingham.ac.uk>
 Date: Wed, 6 Apr 2022 21:25:13 -0700
-Subject: [PATCH 4/15] make int return values
+Subject: [PATCH 4/17] make int return values
 
 The return values of f2c functions are insignificant in most cases, so often it
 is treated as returning void, when it really should return int (values are

--- a/packages/scipy/patches/0005-Fix-fitpack.patch
+++ b/packages/scipy/patches/0005-Fix-fitpack.patch
@@ -1,7 +1,7 @@
 From c784d3a1ee38da88943364de4ea847a3b9cd155f Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Tue, 30 Aug 2022 11:51:53 -0700
-Subject: [PATCH 6/15] Fix fitpack
+Subject: [PATCH 5/17] Fix fitpack
 
 ---
  scipy/interpolate/fitpack/dblint.f | 9 ++++-----

--- a/packages/scipy/patches/0006-Fix-gees-calls.patch
+++ b/packages/scipy/patches/0006-Fix-gees-calls.patch
@@ -1,7 +1,7 @@
 From 8addc1da35bc63df651946ef14c723797a431e0c Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Mon, 26 Jun 2023 20:12:25 -0700
-Subject: [PATCH 7/15] Fix gees calls
+Subject: [PATCH 6/17] Fix gees calls
 
 ---
  scipy/linalg/flapack_gen.pyf.src | 8 ++++----

--- a/packages/scipy/patches/0007-MAINT-linalg-Remove-id_dist-Fortran-files.patch
+++ b/packages/scipy/patches/0007-MAINT-linalg-Remove-id_dist-Fortran-files.patch
@@ -1,7 +1,7 @@
 From 12ba8a395ce04194074a24d362143c22e7ac54bd Mon Sep 17 00:00:00 2001
 From: Ilhan Polat <ilhanpolat@gmail.com>
 Date: Tue, 23 Apr 2024 09:26:38 +0200
-Subject: [PATCH 8/15] MAINT:linalg:Remove id_dist Fortran files
+Subject: [PATCH 7/17] MAINT:linalg:Remove id_dist Fortran files
 
 [skip ci]
 
@@ -41,7 +41,7 @@ DOC:linalg: Fix grammar and typos
  scipy/linalg/_decomp_interpolative.pyx        | 1992 +++++++++++
  scipy/linalg/_interpolative_backend.py        | 1681 ---------
  scipy/linalg/interpolative.py                 |  316 +-
- scipy/linalg/meson.build                      |   56 +-
+ scipy/linalg/meson.build                      |   55 +-
  scipy/linalg/src/id_dist/README.txt           |    6 -
  scipy/linalg/src/id_dist/doc/doc.bib          |   19 -
  scipy/linalg/src/id_dist/doc/doc.tex          |  977 ------
@@ -83,7 +83,7 @@ DOC:linalg: Fix grammar and typos
  scipy/linalg/src/id_dist/src/idzr_rsvd.f      |  159 -
  scipy/linalg/src/id_dist/src/prini.f          |  113 -
  scipy/linalg/tests/test_interpolative.py      |   78 +-
- 46 files changed, 2159 insertions(+), 18884 deletions(-)
+ 46 files changed, 2159 insertions(+), 18883 deletions(-)
  create mode 100644 scipy/linalg/_decomp_interpolative.pyx
  delete mode 100644 scipy/linalg/_interpolative_backend.py
  delete mode 100644 scipy/linalg/src/id_dist/README.txt
@@ -128,10 +128,10 @@ DOC:linalg: Fix grammar and typos
  delete mode 100644 scipy/linalg/src/id_dist/src/prini.f
 
 diff --git a/mypy.ini b/mypy.ini
-index 7613a464c..9c06dcb6c 100644
+index 4417af39dc..4bdbdf9750 100644
 --- a/mypy.ini
 +++ b/mypy.ini
-@@ -131,7 +131,7 @@ ignore_missing_imports = True
+@@ -140,7 +140,7 @@ ignore_missing_imports = True
  [mypy-scipy.linalg._solve_toeplitz]
  ignore_missing_imports = True
  
@@ -4441,11 +4441,10 @@ diff --git a/scipy/linalg/meson.build b/scipy/linalg/meson.build
 index cc208092e..777edd008 100644
 --- a/scipy/linalg/meson.build
 +++ b/scipy/linalg/meson.build
-@@ -103,58 +103,15 @@ interpolative_module = custom_target('interpolative_module',
-   input: 'interpolative.pyf',
-   command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
- )
--
+@@ -111,57 +111,15 @@ py3.extension_module('_flapack',
+ 
+ # TODO: cblas/clapack are built *only* for ATLAS. Why? Is it still needed?
+ 
 -# id_dist contains a copy of FFTPACK, which has type mismatch warnings
 -# that are hard to fix. This code is terrible and noisy during the build,
 -# silence it completely.
@@ -4489,7 +4488,7 @@ index cc208092e..777edd008 100644
 -    'src/id_dist/src/idzr_rid.f',
 -    'src/id_dist/src/idzr_rsvd.f',
 -    'src/id_dist/src/prini.f',
--    interpolative_module,
+-    f2py_gen.process('interpolative.pyf'),
 -  ],
 -  fortran_args: [fortran_ignore_warnings, _suppress_all_warnings],
 +# _decomp_interpolative
@@ -4499,14 +4498,14 @@ index cc208092e..777edd008 100644
 +  dependencies: np_dep,
 +  c_args: numpy_nodepr_api,
    link_args: version_link_args,
--  dependencies: [lapack, fortranobject_dep],
+-  dependencies: [lapack_dep, fortranobject_dep],
    override_options: ['b_lto=false'],
    install: true,
 -  link_language: 'fortran',
    subdir: 'scipy/linalg'
  )
  
-@@ -273,7 +230,6 @@ python_sources = [
+@@ -278,7 +236,6 @@ python_sources = [
    '_decomp_schur.py',
    '_decomp_svd.py',
    '_expm_frechet.py',

--- a/packages/scipy/patches/0008-Mark-mvndst-functions-recursive.patch
+++ b/packages/scipy/patches/0008-Mark-mvndst-functions-recursive.patch
@@ -1,7 +1,7 @@
 From c11745d763407d9a2bb195a21e2a8afaf7635248 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Sat, 6 Jul 2024 22:38:55 +0200
-Subject: [PATCH 9/15] Mark mvndst functions recursive
+Subject: [PATCH 8/17] Mark mvndst functions recursive
 
 ---
  scipy/stats/mvndst.f | 8 ++++----

--- a/packages/scipy/patches/0009-Make-sreorth-recursive.patch
+++ b/packages/scipy/patches/0009-Make-sreorth-recursive.patch
@@ -1,7 +1,7 @@
 From e4d1a570fa8bd4c710e10400822f60232e6408eb Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Sat, 6 Jul 2024 22:33:51 +0200
-Subject: [PATCH 10/15] Make sreorth recursive
+Subject: [PATCH 9/17] Make sreorth recursive
 
 ---
  complex16/zreorth.F | 6 +++---

--- a/packages/scipy/patches/0010-Link-openblas-with-modules-that-require-f2c.patch
+++ b/packages/scipy/patches/0010-Link-openblas-with-modules-that-require-f2c.patch
@@ -1,12 +1,14 @@
 From ccbb0fa0884d567c6139eeed7dc2dc9f8db4db3a Mon Sep 17 00:00:00 2001
 From: ryanking13 <def6488@gmail.com>
 Date: Sun, 28 Jul 2024 18:15:17 +0900
-Subject: [PATCH 11/15] Link openblas with modules that require f2c
+Subject: [PATCH 10/17] Link openblas with modules that require f2c
 
 Some fortran modules require symbols from f2c, which is provided by
 openblas.
 This patch adds openblas as a dependency to the modules that require f2c
 symbols.
+
+Co-Developed-by: Agriya Khetarpal <74401230+agriyakhetarpal@users.noreply.github.com>
 ---
  scipy/integrate/meson.build | 2 +-
  scipy/optimize/meson.build  | 6 +++---
@@ -14,11 +16,11 @@ symbols.
  3 files changed, 5 insertions(+), 5 deletions(-)
 
 diff --git a/scipy/integrate/meson.build b/scipy/integrate/meson.build
-index edee2ca0ba..6f482db5fc 100644
+index 23a715dd58..e5cd9ad4c8 100644
 --- a/scipy/integrate/meson.build
 +++ b/scipy/integrate/meson.build
-@@ -167,7 +167,7 @@ py3.extension_module('_dop',
-   _dop_module,
+@@ -154,7 +154,7 @@ py3.extension_module('_dop',
+   f2py_gen.process('dop.pyf'),
    link_with: [dop_lib],
    c_args: [Wno_unused_variable],
 -  dependencies: [fortranobject_dep],
@@ -27,10 +29,10 @@ index edee2ca0ba..6f482db5fc 100644
    install: true,
    link_language: 'fortran',
 diff --git a/scipy/optimize/meson.build b/scipy/optimize/meson.build
-index 3dfe128749..45c23f43bc 100644
+index d6c20d3d53..d7f0284b5b 100644
 --- a/scipy/optimize/meson.build
 +++ b/scipy/optimize/meson.build
-@@ -134,7 +134,7 @@ py3.extension_module('_cobyla',
+@@ -125,7 +125,7 @@ py3.extension_module('_cobyla',
    c_args: [Wno_unused_variable],
    fortran_args: fortran_ignore_warnings,
    link_args: version_link_args,
@@ -39,8 +41,8 @@ index 3dfe128749..45c23f43bc 100644
    install: true,
    link_language: 'fortran',
    subdir: 'scipy/optimize'
-@@ -150,7 +150,7 @@ py3.extension_module('_minpack2',
-   [minpack2_module, 'minpack2/dcsrch.f', 'minpack2/dcstep.f'],
+@@ -135,7 +135,7 @@ py3.extension_module('_minpack2',
+   [f2py_gen.process('minpack2/minpack2.pyf'), 'minpack2/dcsrch.f', 'minpack2/dcstep.f'],
    fortran_args: fortran_ignore_warnings,
    link_args: version_link_args,
 -  dependencies: [fortranobject_dep],
@@ -48,8 +50,8 @@ index 3dfe128749..45c23f43bc 100644
    override_options: ['b_lto=false'],
    install: true,
    link_language: 'fortran',
-@@ -167,7 +167,7 @@ py3.extension_module('_slsqp',
-   [slsqp_module, 'slsqp/slsqp_optmz.f'],
+@@ -146,7 +146,7 @@ py3.extension_module('_slsqp',
+   [f2py_gen.process('slsqp/slsqp.pyf'), 'slsqp/slsqp_optmz.f'],
    fortran_args: fortran_ignore_warnings,
    link_args: version_link_args,
 -  dependencies: [fortranobject_dep],
@@ -58,10 +60,10 @@ index 3dfe128749..45c23f43bc 100644
    link_language: 'fortran',
    subdir: 'scipy/optimize'
 diff --git a/scipy/stats/meson.build b/scipy/stats/meson.build
-index 33b12574a8..d97168ab49 100644
+index bb43e3b2e9..358279a93b 100644
 --- a/scipy/stats/meson.build
 +++ b/scipy/stats/meson.build
-@@ -43,7 +43,7 @@ py3.extension_module('_mvn',
+@@ -36,7 +36,7 @@ py3.extension_module('_mvn',
    # Wno-surprising is to suppress a pointless warning with GCC 10-12
    # (see GCC bug 98411: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=98411)
    fortran_args: [fortran_ignore_warnings, _fflag_Wno_surprising],

--- a/packages/scipy/patches/0011-Remove-fpchec-inline-if-then-endif-constructs.patch
+++ b/packages/scipy/patches/0011-Remove-fpchec-inline-if-then-endif-constructs.patch
@@ -1,7 +1,16 @@
 From b43a231f8326d6953929030131c3fb6b2cb163bd Mon Sep 17 00:00:00 2001
 From: Agriya Khetarpal <74401230+agriyakhetarpal@users.noreply.github.com>
 Date: Wed, 15 May 2024 21:29:02 +0530
-Subject: [PATCH 12/15] Remove fpchec inline if-else constructs
+Subject: [PATCH 11/17] Remove fpchec inline if-then-endif constructs
+
+This PR removes the single-line if-then-endif constructs in fpchec.f
+that were causing syntactical errors when compiling with f2c, possibly
+because fpchec uses some dated, punch-card FORTRAN syntax. It converts
+them to statements split over multiple lines.
+
+This patch has been upstreamed via https://github.com/scipy/scipy/pull/21365
+and it can be safely removed once SciPy v1.15.0 is released and is being
+integrated in Pyodide.
 
 ---
  scipy/interpolate/fitpack/fpchec.f | 42 +++++++++++++++++++++++-------

--- a/packages/scipy/patches/0012-Remove-chla_transtype.patch
+++ b/packages/scipy/patches/0012-Remove-chla_transtype.patch
@@ -1,7 +1,7 @@
 From 848c94e218e89d866978fbc883cbb2d919f56ce9 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Wed, 31 Jul 2024 10:29:47 +0200
-Subject: [PATCH 13/15] Remove chla_transtype
+Subject: [PATCH 12/17] Remove chla_transtype
 
 The signature should probably be `int chla_transtype(char* res, int *trans)`.
 This just deletes it entirely due to laziness.

--- a/packages/scipy/patches/0013-Set-wrapper-return-type-to-int.patch
+++ b/packages/scipy/patches/0013-Set-wrapper-return-type-to-int.patch
@@ -1,25 +1,25 @@
 From b5d05197de084ab3cab52241f163bae7519b6027 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Wed, 31 Jul 2024 11:48:12 +0200
-Subject: [PATCH 14/15] Set wrapper return type to int
+Subject: [PATCH 13/17] Set wrapper return type to int
 
 ---
  scipy/linalg/_generate_pyx.py | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/scipy/linalg/_generate_pyx.py b/scipy/linalg/_generate_pyx.py
-index a8078f7ab..1bc2dcc7c 100644
+index 8a00f5d279..aeb86e8926 100644
 --- a/scipy/linalg/_generate_pyx.py
 +++ b/scipy/linalg/_generate_pyx.py
-@@ -483,7 +483,7 @@ def generate_decl_c(name, return_type, argnames, argtypes):
+@@ -520,7 +520,7 @@ def generate_decl_c(name, return_type, argnames, argtypes, accelerate):
      if name in WRAPPED_FUNCS:
          argnames = ['out'] + argnames
          c_argtypes = [c_return_type] + c_argtypes
 -        c_return_type = 'void'
 +        c_return_type = 'int'
-     blas_macro, blas_name = get_blas_macro_and_name(name)
+     blas_macro, blas_name = get_blas_macro_and_name(name, accelerate)
      c_args = ', '.join(f'{t} *{n}' for t, n in zip(c_argtypes, argnames))
      return f"{c_return_type} {blas_macro}({blas_name})({c_args});\n"
 -- 
-2.34.1
+2.39.3 (Apple Git-146)
 

--- a/packages/scipy/patches/0014-Skip-svd_gesdd-test.patch
+++ b/packages/scipy/patches/0014-Skip-svd_gesdd-test.patch
@@ -1,7 +1,7 @@
 From 59d3efdf9e55958c6a3651e8eda2a9d6fe48e192 Mon Sep 17 00:00:00 2001
 From: Agriya Khetarpal <74401230+agriyakhetarpal@users.noreply.github.com>
 Date: Fri, 9 Aug 2024 19:00:41 +0530
-Subject: [PATCH 15/15] Skip svd_gesdd test
+Subject: [PATCH 14/17] Skip svd_gesdd test
 
 This patch excludes a test for gesdd which was introduced in this PR:
 https://github.com/scipy/scipy/pull/20349. It is not useful for Pyodide
@@ -13,14 +13,21 @@ and it can be safely removed once SciPy v1.15.0 is released and is being
 integrated in Pyodide.
 
 ---
- scipy/linalg/tests/test_decomp.py | 6 +++++-
- 1 file changed, 5 insertions(+), 1 deletion(-)
+ scipy/linalg/tests/test_decomp.py | 6 ++++++
+ 1 file changed, 6 insertions(+)
 
 diff --git a/scipy/linalg/tests/test_decomp.py b/scipy/linalg/tests/test_decomp.py
-index 8722b31468..2b8580bb41 100644
+index b43016c027..cbd80252b1 100644
 --- a/scipy/linalg/tests/test_decomp.py
 +++ b/scipy/linalg/tests/test_decomp.py
-@@ -38,6 +38,8 @@ try:
+@@ -1,5 +1,6 @@
+ import itertools
+ import platform
++import sys
+ 
+ import numpy as np
+ from numpy.testing import (assert_equal, assert_almost_equal,
+@@ -37,6 +38,8 @@ try:
  except ImportError:
      CONFIG = None
  
@@ -29,16 +36,16 @@ index 8722b31468..2b8580bb41 100644
  
  def _random_hermitian_matrix(n, posdef=False, dtype=float):
      "Generate random sym/hermitian array of the given size n"
-@@ -1089,7 +1091,9 @@ class TestSVD_GESDD:
- class TestSVD_GESVD(TestSVD_GESDD):
+@@ -1179,6 +1182,9 @@ class TestSVD_GESVD(TestSVD_GESDD):
      lapack_driver = 'gesvd'
  
--
+ 
 +# Allocating an array of such a size leads to _ArrayMemoryError(s)
 +# since the maximum memory that can be in 32-bit (WASM) is 4GB
 +@pytest.mark.skipif(IS_WASM, reason="out of memory in WASM")
+ @pytest.mark.fail_slow(5)
  def test_svd_gesdd_nofegfault():
      # svd(a) with {U,VT}.size > INT_MAX does not segfault
-     # cf https://github.com/scipy/scipy/issues/14001
 -- 
 2.39.3 (Apple Git-146)
+

--- a/packages/scipy/patches/0015-Remove-f2py-generator.patch
+++ b/packages/scipy/patches/0015-Remove-f2py-generator.patch
@@ -1,0 +1,304 @@
+From 9b670bd5330bd7834d157a9ec3087a97b71d6516 Mon Sep 17 00:00:00 2001
+From: Agriya Khetarpal <74401230+agriyakhetarpal@users.noreply.github.com>
+Date: Fri, 16 Aug 2024 22:59:26 +0530
+Subject: [PATCH 15/17] Remove f2py generator
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This patch reverts changes made in d85ba6b910ea9040b6a72bdc4ea87d151118f41d
+and is applied at the end, after the rest of the patches – the order is important.
+
+It removes the f2py generator and replaces it with custom targets mapping to
+f2py-generated wrappers. This is done to avoid the need for the f2py executable
+to be present in the environment where SciPy is built. Instead, the Python
+executable is used to run f2py as a module which is useful where f2py is not
+present on PATH.
+
+---
+ scipy/integrate/meson.build              | 32 +++++++++++++++++++++---
+ scipy/interpolate/meson.build            |  8 +++++-
+ scipy/io/meson.build                     |  8 +++++-
+ scipy/meson.build                        | 24 ------------------
+ scipy/optimize/meson.build               | 30 +++++++++++++++++++---
+ scipy/sparse/linalg/_propack/meson.build |  8 +++++-
+ scipy/stats/meson.build                  |  8 +++++-
+ tools/generate_f2pymod.py                |  3 ++-
+ 8 files changed, 85 insertions(+), 36 deletions(-)
+
+diff --git a/scipy/integrate/meson.build b/scipy/integrate/meson.build
+index cfaa927139..44c63fa526 100644
+--- a/scipy/integrate/meson.build
++++ b/scipy/integrate/meson.build
+@@ -128,8 +128,14 @@ py3.extension_module('_odepack',
+   subdir: 'scipy/integrate'
+ )
+ 
++vode_module = custom_target('vode_module',
++  output: ['_vode-f2pywrappers.f', '_vodemodule.c'],
++  input: 'vode.pyf',
++  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
++)
++
+ py3.extension_module('_vode',
+-  f2py_gen.process('vode.pyf'),
++  vode_module,
+   link_with: [vode_lib],
+   c_args: [Wno_unused_variable],
+   link_args: version_link_args,
+@@ -139,8 +145,14 @@ py3.extension_module('_vode',
+   subdir: 'scipy/integrate'
+ )
+ 
++lsoda_module = custom_target('lsoda_module',
++  output: ['_lsoda-f2pywrappers.f', '_lsodamodule.c'],
++  input: 'lsoda.pyf',
++  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
++)
++
+ py3.extension_module('_lsoda',
+-  f2py_gen.process('lsoda.pyf'),
++  lsoda_module,
+   link_with: [lsoda_lib, mach_lib],
+   c_args: [Wno_unused_variable],
+   dependencies: [lapack_dep, fortranobject_dep],
+@@ -150,8 +162,14 @@ py3.extension_module('_lsoda',
+   subdir: 'scipy/integrate'
+ )
+ 
++_dop_module = custom_target('_dop_module',
++  output: ['_dop-f2pywrappers.f', '_dopmodule.c'],
++  input: 'dop.pyf',
++  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
++)
++
+ py3.extension_module('_dop',
+-  f2py_gen.process('dop.pyf'),
++  _dop_module,
+   link_with: [dop_lib],
+   c_args: [Wno_unused_variable],
+   dependencies: [lapack, fortranobject_dep],
+@@ -169,8 +187,14 @@ py3.extension_module('_test_multivariate',
+   install_tag: 'tests'
+ )
+ 
++_test_odeint_banded_module = custom_target('_test_odeint_banded_module',
++  output: ['_test_odeint_bandedmodule.c', '_test_odeint_banded-f2pywrappers.f'],
++  input: 'tests/test_odeint_banded.pyf',
++  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
++)
++
+ py3.extension_module('_test_odeint_banded',
+-  ['tests/banded5x5.f', f2py_gen.process('tests/test_odeint_banded.pyf')],
++  ['tests/banded5x5.f', _test_odeint_banded_module],
+   link_with: [lsoda_lib, mach_lib],
+   fortran_args: _fflag_Wno_unused_dummy_argument,
+   link_args: version_link_args,
+diff --git a/scipy/interpolate/meson.build b/scipy/interpolate/meson.build
+index 69ec25f6af..38dd2a8cc3 100644
+--- a/scipy/interpolate/meson.build
++++ b/scipy/interpolate/meson.build
+@@ -143,9 +143,15 @@ py3.extension_module('_fitpack',
+   subdir: 'scipy/interpolate'
+ )
+ 
++dfitpack_module = custom_target('dfitpack_module',
++  output: ['_dfitpack-f2pywrappers.f', '_dfitpackmodule.c'],
++  input: 'src/dfitpack.pyf',
++  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
++)
++
+ # TODO: Add flags for 64 bit ints
+ py3.extension_module('_dfitpack',
+-  f2py_gen.process('src/dfitpack.pyf'),
++  dfitpack_module,
+   c_args: [Wno_unused_variable],
+   link_args: version_link_args,
+   dependencies: [lapack_dep, fortranobject_dep],
+diff --git a/scipy/io/meson.build b/scipy/io/meson.build
+index 60f71c6968..89a9cf69ba 100644
+--- a/scipy/io/meson.build
++++ b/scipy/io/meson.build
+@@ -1,6 +1,12 @@
++_test_fortran_module = custom_target('_test_fortran_module',
++  output: ['_test_fortranmodule.c'],
++  input: 'test_fortran.pyf',
++  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
++)
++
+ py3.extension_module('_test_fortran',
+   [
+-    f2py_gen.process('test_fortran.pyf'),
++    _test_fortran_module,
+     '_test_fortran.f'
+   ],
+   c_args: [Wno_unused_variable],
+diff --git a/scipy/meson.build b/scipy/meson.build
+index a0857848a2..ff47bde52e 100644
+--- a/scipy/meson.build
++++ b/scipy/meson.build
+@@ -144,30 +144,6 @@ fortranobject_dep = declare_dependency(
+   compile_args: _f2py_c_args,
+ )
+ 
+-f2py = find_program('f2py')
+-# It should be quite rare for the `f2py` executable to not be the one from
+-# `numpy` installed in the Python env we are building for (unless we are
+-# cross-compiling). If it is from a different env, that is still fine as long
+-# as it's not too old. We are only using f2py as a code generator, and the
+-# output is not dependent on platform or Python version (see gh-20612 for more
+-# details).
+-# This should be robust enough. If not, we can make this more complex, using
+-# a fallback to `python -m f2py` rather than erroring out.
+-f2py_version = run_command([f2py, '-v'], check: true).stdout().strip()
+-if f2py_version.version_compare('<'+min_numpy_version)
+-  error(f'Found f2py executable is too old: @f2py_version@')
+-endif
+-
+-# Note: this generato cannot handle:
+-# 1. `.pyf.src` files, because `@BASENAME@` will still include .pyf
+-# 2. targets with #include's (due to no `depend_files` - see feature request
+-#    at meson#8295)
+-f2py_gen = generator(generate_f2pymod,
+-  arguments : ['@INPUT@', '-o', '@BUILD_DIR@'],
+-  output : ['_@BASENAME@module.c', '_@BASENAME@-f2pywrappers.f'],
+-)
+-
+-
+ # TODO: 64-bit BLAS and LAPACK
+ #
+ # Note that this works as long as BLAS and LAPACK are detected properly via
+diff --git a/scipy/optimize/meson.build b/scipy/optimize/meson.build
+index 50d62ef68b..6cef85027a 100644
+--- a/scipy/optimize/meson.build
++++ b/scipy/optimize/meson.build
+@@ -92,12 +92,18 @@ py3.extension_module('_zeros',
+   subdir: 'scipy/optimize'
+ )
+ 
++lbfgsb_module = custom_target('lbfgsb_module',
++  output: ['_lbfgsb-f2pywrappers.f', '_lbfgsbmodule.c'],
++  input: 'lbfgsb_src/lbfgsb.pyf',
++  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
++)
++
+ py3.extension_module('_lbfgsb',
+   [
+     'lbfgsb_src/lbfgsb.f',
+     'lbfgsb_src/linpack.f',
+     'lbfgsb_src/timer.f',
+-    f2py_gen.process('lbfgsb_src/lbfgsb.pyf'),
++    lbfgsb_module,
+   ],
+   fortran_args: fortran_ignore_warnings,
+   link_args: version_link_args,
+@@ -120,6 +126,12 @@ py3.extension_module('_moduleTNC',
+   subdir: 'scipy/optimize'
+ )
+ 
++cobyla_module = custom_target('cobyla_module',
++  output: ['_cobylamodule.c'],
++  input: 'cobyla/cobyla.pyf',
++  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
++)
++
+ py3.extension_module('_cobyla',
+-  [f2py_gen.process('cobyla/cobyla.pyf'), 'cobyla/cobyla2.f', 'cobyla/trstlp.f'],
++  [cobyla_module, 'cobyla/cobyla2.f', 'cobyla/trstlp.f'],
+   c_args: [Wno_unused_variable],
+@@ -131,8 +143,14 @@ py3.extension_module('_cobyla',
+   subdir: 'scipy/optimize'
+ )
+ 
++minpack2_module = custom_target('minpack2_module',
++  output: ['_minpack2module.c'],
++  input: 'minpack2/minpack2.pyf',
++  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
++)
++
+ py3.extension_module('_minpack2',
+-  [f2py_gen.process('minpack2/minpack2.pyf'), 'minpack2/dcsrch.f', 'minpack2/dcstep.f'],
++  [minpack2_module, 'minpack2/dcsrch.f', 'minpack2/dcstep.f'],
+   fortran_args: fortran_ignore_warnings,
+   link_args: version_link_args,
+   dependencies: [lapack, fortranobject_dep],
+@@ -142,8 +160,14 @@ py3.extension_module('_minpack2',
+   subdir: 'scipy/optimize'
+ )
+ 
++slsqp_module = custom_target('slsqp_module',
++  output: ['_slsqpmodule.c'],
++  input: 'slsqp/slsqp.pyf',
++  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
++)
++
+ py3.extension_module('_slsqp',
+-  [f2py_gen.process('slsqp/slsqp.pyf'), 'slsqp/slsqp_optmz.f'],
++  [slsqp_module, 'slsqp/slsqp_optmz.f'],
+   fortran_args: fortran_ignore_warnings,
+   link_args: version_link_args,
+   dependencies: [fortranobject_dep],
+diff --git a/scipy/sparse/linalg/_propack/meson.build b/scipy/sparse/linalg/_propack/meson.build
+index 6714724958..df358df651 100644
+--- a/scipy/sparse/linalg/_propack/meson.build
++++ b/scipy/sparse/linalg/_propack/meson.build
+@@ -97,8 +97,14 @@ foreach ele: elements
+     gnu_symbol_visibility: 'hidden',
+   )
+ 
++  propack_module = custom_target('propack_module' + ele[0],
++    output: [ele[0] + '-f2pywrappers.f', ele[0] + 'module.c'],
++    input: ele[2],
++    command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
++  )
++
+   propacklib = py3.extension_module(ele[0],
+-    f2py_gen.process(ele[2]),
++    propack_module,
+     link_with: propack_lib,
+     c_args: ['-U_OPENMP', _cpp_Wno_cpp],
+     fortran_args: _fflag_Wno_maybe_uninitialized,
+diff --git a/scipy/stats/meson.build b/scipy/stats/meson.build
+index 358279a93b..7c973b1cf3 100644
+--- a/scipy/stats/meson.build
++++ b/scipy/stats/meson.build
+@@ -31,8 +31,14 @@ py3.extension_module('_ansari_swilk_statistics',
+   subdir: 'scipy/stats'
+ )
+ 
++mvn_module = custom_target('mvn_module',
++  output: ['_mvn-f2pywrappers.f', '_mvnmodule.c'],
++  input: 'mvn.pyf',
++  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
++)
++
+ py3.extension_module('_mvn',
+-  [f2py_gen.process('mvn.pyf'), 'mvndst.f'],
++  [mvn_module, 'mvndst.f'],
+   # Wno-surprising is to suppress a pointless warning with GCC 10-12
+   # (see GCC bug 98411: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=98411)
+   fortran_args: [fortran_ignore_warnings, _fflag_Wno_surprising],
+diff --git a/tools/generate_f2pymod.py b/tools/generate_f2pymod.py
+index b6bc02eb04..3da75c14d1 100644
+--- a/tools/generate_f2pymod.py
++++ b/tools/generate_f2pymod.py
+@@ -9,6 +9,7 @@ import argparse
+ import os
+ import re
+ import subprocess
++import sys
+ 
+ 
+ # START OF CODE VENDORED FROM `numpy.distutils.from_template`
+@@ -283,7 +284,7 @@ def main():
+ 
+     # Now invoke f2py to generate the C API module file
+     if args.infile.endswith(('.pyf.src', '.pyf')):
+-        p = subprocess.Popen(['f2py', fname_pyf,
++        p = subprocess.Popen([sys.executable, '-m', 'numpy.f2py', fname_pyf,
+                             '--build-dir', outdir_abs], #'--quiet'],
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                             cwd=os.getcwd())
+-- 
+2.39.3 (Apple Git-146)
+

--- a/packages/scipy/patches/0016-Make-sf_error_state_lib-a-static-library.patch
+++ b/packages/scipy/patches/0016-Make-sf_error_state_lib-a-static-library.patch
@@ -1,0 +1,28 @@
+From 9d93ca19f4ad0ca327964b6234316547d774b17f Mon Sep 17 00:00:00 2001
+From: Agriya Khetarpal <74401230+agriyakhetarpal@users.noreply.github.com>
+Date: Sat, 17 Aug 2024 01:12:28 +0530
+Subject: [PATCH 16/17] Make `sf_error_state_lib` a static library
+
+wasm.ld does not support linkage with shared libraries. This patch
+changes `sf_error_state_lib` to a static one.
+
+---
+ scipy/special/meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/scipy/special/meson.build b/scipy/special/meson.build
+index 82b813ea85..24bee0a21c 100644
+--- a/scipy/special/meson.build
++++ b/scipy/special/meson.build
+@@ -33,7 +33,7 @@ else
+   scipy_import_dll_args = []
+ endif
+ 
+-sf_error_state_lib = shared_library('sf_error_state',
++sf_error_state_lib = static_library('sf_error_state',
+   ['sf_error_state.c'],
+   include_directories: ['../_lib', '../_build_utils/src'],
+   c_args: scipy_export_dll_args,
+-- 
+2.39.3 (Apple Git-146)
+

--- a/packages/scipy/patches/0017-Remove-test-modules-that-fail-to-build.patch
+++ b/packages/scipy/patches/0017-Remove-test-modules-that-fail-to-build.patch
@@ -1,28 +1,28 @@
 From e21f33695da3275ec81b5f94685f0e4ac92c9ad5 Mon Sep 17 00:00:00 2001
 From: Gyeongjae Choi <def6488@gmail.com>
 Date: Mon, 30 Oct 2023 14:35:04 +0000
-Subject: [PATCH 5/15] Remove test modules that fails to build
+Subject: [PATCH 17/17] Remove test modules that fail to build
 
 These are tests and they have both void vs int return value problems and implicit
 function argument cast problems. Not worth fixing for tests.
 
 ---
- scipy/integrate/meson.build | 17 -----------------
- scipy/io/meson.build        | 20 --------------------
- 2 files changed, 37 deletions(-)
+ scipy/integrate/meson.build | 18 ------------------
+ scipy/io/meson.build        | 21 ---------------------
+ 2 files changed, 39 deletions(-)
 
 diff --git a/scipy/integrate/meson.build b/scipy/integrate/meson.build
-index edee2ca0ba..c20243ef61 100644
+index ae9e2466e1..e11626db0d 100644
 --- a/scipy/integrate/meson.build
 +++ b/scipy/integrate/meson.build
-@@ -181,23 +181,6 @@ py3.extension_module('_test_multivariate',
-   subdir: 'scipy/integrate'
+@@ -187,24 +187,6 @@ py3.extension_module('_test_multivariate',
+   install_tag: 'tests'
  )
  
 -_test_odeint_banded_module = custom_target('_test_odeint_banded_module',
 -  output: ['_test_odeint_bandedmodule.c', '_test_odeint_banded-f2pywrappers.f'],
--  input: 'tests/banded5x5.pyf',
--  command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
+-  input: 'tests/test_odeint_banded.pyf',
+-  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 -)
 -
 -py3.extension_module('_test_odeint_banded',
@@ -30,24 +30,25 @@ index edee2ca0ba..c20243ef61 100644
 -  link_with: [lsoda_lib, mach_lib],
 -  fortran_args: _fflag_Wno_unused_dummy_argument,
 -  link_args: version_link_args,
--  dependencies: [lapack, fortranobject_dep],
+-  dependencies: [lapack_dep, fortranobject_dep],
 -  install: true,
 -  link_language: 'fortran',
--  subdir: 'scipy/integrate'
+-  subdir: 'scipy/integrate',
+-  install_tag: 'tests'
 -)
 -
  subdir('_ivp')
  subdir('tests')
  
 diff --git a/scipy/io/meson.build b/scipy/io/meson.build
-index b41f29022c..af04022208 100644
+index d6fc6dc749..af04022208 100644
 --- a/scipy/io/meson.build
 +++ b/scipy/io/meson.build
-@@ -1,23 +1,3 @@
+@@ -1,24 +1,3 @@
 -_test_fortran_module = custom_target('_test_fortran_module',
 -  output: ['_test_fortranmodule.c'],
--  input: '_test_fortran.pyf',
--  command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
+-  input: 'test_fortran.pyf',
+-  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 -)
 -
 -py3.extension_module('_test_fortran',
@@ -58,15 +59,16 @@ index b41f29022c..af04022208 100644
 -  c_args: [Wno_unused_variable],
 -  fortran_args: fortran_ignore_warnings,
 -  link_args: version_link_args,
--  dependencies: [lapack, fortranobject_dep],
+-  dependencies: [lapack_dep, fortranobject_dep],
 -  install: true,
 -  link_language: 'fortran',
--  subdir: 'scipy/io'
+-  subdir: 'scipy/io',
+-  install_tag: 'tests'
 -)
 -
  py3.install_sources([
      '__init__.py',
      '_fortran.py',
 -- 
-2.34.1
+2.39.3 (Apple Git-146)
 

--- a/packages/scipy/scipy-conftest.py
+++ b/packages/scipy/scipy-conftest.py
@@ -14,6 +14,8 @@ thread_msg = "no thread support"
 todo_signature_mismatch_msg = "TODO signature mismatch"
 todo_memory_corruption_msgt = "TODO memory corruption"
 todo_genuine_difference_msg = "TODO genuine difference to be investigated"
+todo_fp_exception_msg = "TODO did not raise maybe no floating point exception support?"
+
 
 tests_to_mark = [
     # scipy/_lib/tests
@@ -165,6 +167,28 @@ tests_to_mark = [
         skip,
         "TODO C++ exception that causes a Pyodide fatal error",
     ),
+    # The following four tests do not raise the required
+    # <class 'scipy.special._sf_error.SpecialFunctionError'>
+    (
+        "test_basic.py::test_error_raising",
+        xfail,
+        todo_fp_exception_msg,
+    ),
+    (
+        "test_sf_error.py::test_errstate_pyx_basic",
+        xfail,
+        todo_fp_exception_msg,
+    ),
+    (
+        "test_sf_error.py::test_errstate_cpp_scipy_special",
+        xfail,
+        todo_fp_exception_msg,
+    ),
+    (
+        "test_sf_error.py::test_errstate_cpp_alt_ufunc_machinery",
+        xfail,
+        todo_fp_exception_msg,
+    ),
     (
         "test_kdeoth.py::test_kde_[12]d",
         xfail,
@@ -216,7 +240,7 @@ tests_to_mark = [
     (
         "test_qmc.py::TestMultivariateNormalQMC.test_validations",
         xfail,
-        "TODO did not raise maybe no floating point exception support?",
+        todo_fp_exception_msg,
     ),
     (
         "test_qmc.py::TestMultivariateNormalQMC.test_MultivariateNormalQMCDegenerate",
@@ -233,12 +257,12 @@ tests_to_mark = [
     (
         "test_stats.py::TestKSTwoSamples.test_some_code_paths",
         xfail,
-        "TODO did not raise maybe no floating point exception support?",
+        todo_fp_exception_msg,
     ),
     (
         "test_stats.py::TestGeometricStandardDeviation.test_raises_value_error",
         xfail,
-        "TODO did not raise maybe no floating point exception support?",
+        todo_fp_exception_msg,
     ),
     (
         "test_stats.py::TestBrunnerMunzel.test_brunnermunzel_normal_dist",


### PR DESCRIPTION
Release `pyodide-lock.json` file separately from .tar.gz archive so that it can be downloaded without downloading the whole archive. I am going to use this file to make a list of package in the documentation: https://pyodide.org/en/stable/usage/packages-in-pyodide.html