### PR TITLE
Fix renamed import of MetaConfig

### DIFF
--- a/packages/test_packages_common.py
+++ b/packages/test_packages_common.py
@@ -9,7 +9,7 @@ from pytest_pyodide.utils import package_is_built as _package_is_built
 import pytest
 
 from conftest import package_is_built
-from pyodide_build.io import MetaConfig
+from pyodide_build.recipe.spec import MetaConfig
 
 PKG_DIR = Path(__file__).parent
 


### PR DESCRIPTION
It seems like the `MetaConfig` class has been moved from `pyodide_build.io` to `pyodide_build.recipe.spec`. It caused CI in a different draft PR to fail.