### PR TITLE
Add `rustworkx` alpha recipe

### DIFF
--- a/packages/rustworkx/meta.yaml
+++ b/packages/rustworkx/meta.yaml
@@ -9,7 +9,7 @@ source:
   url: https://github.com/IvanIsCoding/rustworkx/releases/download/v0.17.0a3/rustworkx-0.17.0a3.tar.gz
   sha256: 8bd0c295134e2b0c03808d4e69428b41153849db6488839084a78793c337f191
 build:
-  script: export RUSTFLAGS="-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=-sSIDE_MODULE=2 -C link-arg=-sWASM_BIGINT"
+  script: export RUSTFLAGS="-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=-sSIDE_MODULE=2 -C link-arg=-sWASM_BIGINT -Z emscripten-wasm-eh"
 requirements:
   executable:
     - rustup

--- a/packages/rustworkx/meta.yaml
+++ b/packages/rustworkx/meta.yaml
@@ -13,6 +13,9 @@ build:
 requirements:
   executable:
     - rustup
+test:
+  imports:
+    - rustworkx
 about:
   home: https://github.com/Qiskit/rustworkx
   PyPI: https://pypi.org/project/rustworkx

--- a/packages/rustworkx/meta.yaml
+++ b/packages/rustworkx/meta.yaml
@@ -9,7 +9,7 @@ source:
   url: https://github.com/IvanIsCoding/rustworkx/releases/download/v0.17.0a3/rustworkx-0.17.0a3.tar.gz
   sha256: 8bd0c295134e2b0c03808d4e69428b41153849db6488839084a78793c337f191
 build:
-  script: export RUSTFLAGS="-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=-sSIDE_MODULE=2 -C link-arg=-sWASM_BIGINT -Z emscripten-wasm-eh"
+  script: export RUSTFLAGS="$RUSTFLAGS -C target-feature=+atomics,+bulk-memory,+mutable-globals"
 requirements:
   executable:
     - rustup

--- a/packages/rustworkx/meta.yaml
+++ b/packages/rustworkx/meta.yaml
@@ -1,0 +1,23 @@
+package:
+  name: rustworkx
+  version: 0.17.0a3
+  top-level:
+    - rustworkx
+  tag:
+    - rust
+source:
+  url: https://github.com/IvanIsCoding/rustworkx/releases/download/v0.17.0a3/rustworkx-0.17.0a3.tar.gz
+  sha256: 8bd0c295134e2b0c03808d4e69428b41153849db6488839084a78793c337f191
+build:
+  script: export RUSTFLAGS="-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=-s -C link-arg=ALLOW_MEMORY_GROWTH=1 -C link-arg=-s -C link-arg=MODULARIZE=1 -C link-arg=-s -C link-arg=EXPORT_NAME=createModule -C link-arg=-s -C link-arg=EXPORT_ES6=1 -C link-arg=-s -C link-arg=ASSERTIONS=1"
+requirements:
+  executable:
+    - rustup
+about:
+  home: https://github.com/Qiskit/rustworkx
+  PyPI: https://pypi.org/project/rustworkx
+  summary: A python graph library implemented in Rust
+  license: Apache 2.0
+extra:
+  recipe-maintainers:
+    - IvanIsCoding

--- a/packages/rustworkx/meta.yaml
+++ b/packages/rustworkx/meta.yaml
@@ -20,7 +20,7 @@ about:
   home: https://github.com/Qiskit/rustworkx
   PyPI: https://pypi.org/project/rustworkx
   summary: A python graph library implemented in Rust
-  license: Apache 2.0
+  license: Apache-2.0
 extra:
   recipe-maintainers:
     - IvanIsCoding

--- a/packages/rustworkx/meta.yaml
+++ b/packages/rustworkx/meta.yaml
@@ -9,7 +9,7 @@ source:
   url: https://github.com/IvanIsCoding/rustworkx/releases/download/v0.17.0a3/rustworkx-0.17.0a3.tar.gz
   sha256: 8bd0c295134e2b0c03808d4e69428b41153849db6488839084a78793c337f191
 build:
-  script: export RUSTFLAGS="-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=-s -C link-arg=ALLOW_MEMORY_GROWTH=1 -C link-arg=-s -C link-arg=MODULARIZE=1 -C link-arg=-s -C link-arg=EXPORT_NAME=createModule -C link-arg=-s -C link-arg=EXPORT_ES6=1 -C link-arg=-s -C link-arg=ASSERTIONS=1"
+  script: export RUSTFLAGS="-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=-sSIDE_MODULE=2 -C link-arg=-sWASM_BIGINT"
 requirements:
   executable:
     - rustup

--- a/packages/rustworkx/test_rustworkx.py
+++ b/packages/rustworkx/test_rustworkx.py
@@ -16,3 +16,13 @@ def test_isomorphism(selenium):
             )
             expected = (k == t) or (k == n - t) or (k * t % n == 1) or (k * t % n == n - 1)
             assert result == expected
+
+@run_in_pyodide(packages=["rustworkx"])
+def test_rayon_works(selenium):
+    # This essentially tests that multi-threading is set to one core and does not panic
+    import rustworkx
+    graph = rustworkx.generators.cycle_graph(10)
+    path_lenghts_floyd = rustworkx.floyd_warshall(graph)
+    path_lenghts_no_self = rustworkx.all_pairs_dijkstra_path_lengths(graph, lambda _: 1.0)
+    path_lenghts_dijkstra = {k: {**v, k: 0.0} for k, v in path_lenghts_no_self.items()}
+    assert path_lenghts_floyd == path_lenghts_dijkstra

--- a/packages/rustworkx/test_rustworkx.py
+++ b/packages/rustworkx/test_rustworkx.py
@@ -1,0 +1,18 @@
+from pytest_pyodide import run_in_pyodide
+
+
+@run_in_pyodide(packages=["rustworkx"])
+def test_isomorphism(selenium):
+    # Adapted from tests/graph/test_isomorphic.py to work with pytest
+    import rustworkx
+
+    n = 15
+    upper_bound_k = (n - 1) // 2
+    for k in range(1, upper_bound_k + 1):
+        for t in range(k, upper_bound_k + 1):
+            result = rustworkx.is_isomorphic(
+                rustworkx.generators.generalized_petersen_graph(n, k),
+                rustworkx.generators.generalized_petersen_graph(n, t),
+            )
+            expected = (k == t) or (k == n - t) or (k * t % n == 1) or (k * t % n == n - 1)
+            assert result == expected


### PR DESCRIPTION
Related to https://github.com/Qiskit/rustworkx/pull/1447

In short, this adds a very experimental `rustworkx` to Pyodide. If this is the wrong place to submit a recipe, let me know.

At the current status, the other `rustworkx` author has not yet merged the Pyodide support. It also might take a while for us to publish 0.17.0. So I called it a pre-release with `0.17.0a3` and hosted it in my GitHub fork's release. 

Overall, this seems to be working on the browser but failing with Python from `pyodide venv` so I will open an issue on `pyodide-build` asking a couple questions. (edit: report in https://github.com/pyodide/pyodide-build/issues/201)