### PR TITLE
Don't implicitly use Anaconda's defaults channel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,7 @@ jobs:
           miniforge-variant: Miniforge3
           miniforge-version: latest
           activate-environment: pyodide-env
+          conda-remove-defaults: true
           channels: conda-forge
 
       - name: Get Date
@@ -256,6 +257,7 @@ jobs:
           miniforge-variant: Miniforge3
           miniforge-version: latest
           activate-environment: pyodide-env
+          conda-remove-defaults: true
           channels: conda-forge
 
       - name: Get Date
@@ -318,6 +320,7 @@ jobs:
           miniforge-variant: Miniforge3
           miniforge-version: latest
           activate-environment: pyodide-env
+          conda-remove-defaults: true
           channels: conda-forge
 
       - name: Download build artifact


### PR DESCRIPTION
We've been getting warnings about this from the conda-incubator/setup-miniconda GitHub Action, and while we are using only the conda-forge channel, I think it is best that we avoid any sorts of licensing troubles that may arise from any use of the defaults channel.