### PR TITLE
Add imgui_bundle package

### DIFF
--- a/packages/imgui-bundle/demo/Readme.md
+++ b/packages/imgui-bundle/demo/Readme.md
@@ -1,0 +1,27 @@
+This folder contains a demo for Dear ImGui Bundle with Pyodide
+
+### Usage Instructions:
+
+#### Edit demo_imgui_bundle.html and replace the path to pyodide.js with the correct one:
+
+```html
+    <script src="dist/pyodide.js"></script>
+```
+
+#### Start a local HTTP server in this directory:
+```bash
+python -m http.server 8000
+```
+
+#### Open your browser 
+
+Then navigate to http://localhost:8000/demo_imgui_bundle.html
+
+---
+
+#### Building imgui-bundle for Pyodide
+
+If needed, you may build imgui-bundle package for Pyodide (and its dependencies):
+```bash
+pyodide build-recipes numpy Pillow typing-extensions pydantic munch future imgui-bundle --recipe-dir pyodide-recipes/packages --install
+```

--- a/packages/imgui-bundle/demo/demo_imgui_bundle.html
+++ b/packages/imgui-bundle/demo/demo_imgui_bundle.html
@@ -1,0 +1,90 @@
+<!-- Example page using imgui_bundle -->
+<!doctype html>
+<html>
+  <head>
+    <style>
+      html,
+      body {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+      }
+      #canvas {
+        display: block;
+        width: 100%;
+        height: 100%;
+      }
+    </style>
+    <script src="dist/pyodide.js"></script>
+  </head>
+  <body>
+    <canvas id="canvas"></canvas>
+
+    <script type="text/javascript">
+      // ====================== Start of Python code ============================
+      pythonCode = `
+import time
+import numpy as np
+
+from imgui_bundle import implot, imgui, immapp, hello_imgui, icons_fontawesome_4
+
+# Fill x and y whose plot is a heart
+vals = np.arange(0, np.pi * 2, 0.01)
+x = np.power(np.sin(vals), 3) * 16
+y = 13 * np.cos(vals) - 5 * np.cos(2 * vals) - 2 * np.cos(3 * vals) - np.cos(4 * vals)
+# Heart pulse rate and time tracking
+phase = 0.0
+t0 = time.time() + 0.2
+heart_pulse_rate = 80
+
+
+def gui():
+    global heart_pulse_rate, phase, t0, x, y
+
+    imgui.text("Made with " + icons_fontawesome_4.ICON_FA_HEART + " using Dear ImGui and ImPlot")
+    imgui.text(f"Running at {hello_imgui.frame_rate():.1f} FPS")
+
+    t = time.time()
+    phase += (t - t0) * heart_pulse_rate / (np.pi * 2)
+    k = 0.8 + 0.1 * np.cos(phase)
+    t0 = t
+
+    implot.begin_plot("Heart", immapp.em_to_vec2(21, 21))
+    implot.plot_line("", x * k, y * k)
+    implot.end_plot()
+
+    imgui.set_next_item_width(hello_imgui.em_size(10))
+    _, heart_pulse_rate = imgui.slider_float("Pulse", heart_pulse_rate, 30, 180)
+
+
+if __name__ == "__main__":
+    immapp.run(gui, window_size=(300, 450), window_title="Hello!", with_implot=True, fps_idle=0)
+    `;
+      // ====================== End of Python code ==============================
+
+      async function main() {
+        // This enables to use right click in the canvas
+        document.addEventListener("contextmenu", (event) =>
+          event.preventDefault(),
+        );
+
+        // Load Pyodide
+        let pyodide = await loadPyodide();
+
+        // Setup SDL, cf. https://pyodide.org/en/stable/usage/sdl.html
+        // 1. Set the canvas for SDL2
+        let sdl2Canvas = document.getElementById("canvas");
+        pyodide.canvas.setCanvas2D(sdl2Canvas);
+        // 2. SDL requires enabling an opt-in flag
+        pyodide._api._skip_unwind_fatal_error = true;
+
+        // 3. Load imgui_bundle
+        await pyodide.loadPackage("imgui_bundle");
+
+        // Run the Python code
+        pyodide.runPython(pythonCode);
+      }
+      main();
+    </script>
+  </body>
+</html>

--- a/packages/imgui-bundle/meta.yaml
+++ b/packages/imgui-bundle/meta.yaml
@@ -1,0 +1,27 @@
+package:
+  name: imgui-bundle
+  version: 1.92.0
+  top-level:
+    - imgui_bundle
+
+source:
+  url: https://github.com/pthom/imgui_bundle/releases/download/v1.92.0/srcs-full-v1.92.0.tar.gz
+  sha256: 359336ca8edeef3e1313652be86d4a3aacb28962f4906926ca0db3817c27fcdb
+
+build:
+  # imgui-bundle needs to link with relocatable versions of SDL2 and html5.
+  # By default, emscripten builds the non-relocatable version of these libraries,
+  # so we need to trigger the build of the relocatable (-fPIC) versions.
+  # See https://github.com/pyodide/pyodide/issues/5248 for more explanations.
+  script: |
+    embuilder build sdl2 libhtml5 --pic
+
+requirements:
+  run:
+    - pydantic
+    - munch
+    - numpy
+
+extra:
+  recipe-maintainers:
+    - pthom

--- a/packages/imgui-bundle/test_imgui_bundle.py
+++ b/packages/imgui-bundle/test_imgui_bundle.py
@@ -1,0 +1,76 @@
+"""
+Test for the Pyodide build of imgui-bundle
+
+Steps:
+======
+1. Create a <canvas> element in the HTML document.
+2. Use the `imgui_bundle` library to create a simple ImGui application that displays
+   "Hello, ImGui inside Pyodide!" text.
+3. The application runs in a non-blocking manner using `hello_imgui.run()`.
+4. The test waits until the ImGui application signals that it is done rendering.
+5. Finally, it asserts that the application has completed its execution.
+
+Run the test using a browser runtime:
+=====================================
+For example:
+    pytest pyodide-recipes/packages/imgui-bundle --runtime chrome -rs
+
+Notes:
+======
+* This test runs correctly in Chrome.
+
+* This test is expected to fail in Firefox Headless because:
+  * Firefox Headless does not support WebGL unless a virtual display is set up.
+    This might be solved by adding a step in the GitHub Actions workflow to install xvfb + GL drivers.
+  * However, even with a virtual display headless there are remaining issues around requestAnimationFrame
+    so the test is still expected to fail.
+"""
+import pytest
+from pytest_pyodide import run_in_pyodide
+
+
+@pytest.mark.xfail_browsers(firefox="Firefox headless does not support WebGL. Skipping this test", node="Not supported")
+@run_in_pyodide(packages=["imgui-bundle"])
+def test_imgui_bundle_window(selenium):
+    # --- 1. Create / attach a <canvas id="canvas"> -------------------------
+    import js
+    canvas = js.document.getElementById("canvas")
+    if canvas is None:
+        canvas = js.document.createElement("canvas")
+        canvas.id = "canvas"
+        canvas.style.width = "640px"
+        canvas.style.height = "480px"
+        js.document.body.appendChild(canvas)
+
+    js.pyodide.canvas.setCanvas2D(canvas)
+    # opt-in flag required when using SDL2 with Pyodide
+    js.pyodide._api._skip_unwind_fatal_error = True
+
+    # --- 2. Minimal ImGui program -----------------------------------------
+    from imgui_bundle import imgui, hello_imgui
+
+    done = False
+
+    def gui() -> None:
+        nonlocal done
+        imgui.text("Hello, ImGui inside Pyodide!")
+        # Exit after a few frames were rendered
+        if imgui.get_frame_count() > 3:
+            done = True
+
+    # Run the ImGui application
+    # Warning, this is a non-blocking call: it will return immediately (and use requestAnimationFrame)
+    hello_imgui.run(gui)
+
+    # ---------- wait until the GUI says it's done ---------------------------
+    import asyncio, time
+    deadline = time.time() + 6.0      # 6-second safety net (requestAnimationFrame may run slowly in headless mode)
+
+    async def _wait_until_done():
+        while not done and time.time() < deadline:
+            await asyncio.sleep(0.05)
+
+    asyncio.run(_wait_until_done())
+
+    # If we reach here, the loop opened and closed cleanly
+    assert done


### PR DESCRIPTION
### Description

[Dear ImGui Bundle](https://pthom.github.io/imgui_bundle/) provides python bindings for [Dear ImGui](https://github.com/ocornut/imgui) and lots of related libraries.

This PR adds support for the imgui_bundle package to Pyodide. It enables high-performance interactive GUIs (including 3D plotting, Markdown rendering, and immediate mode controls) directly in the browser using pure Python (no need for JavaScript, CSS, or WebAssembly glue code outside Pyodide’s core).

**Demo**

I prepared two demonstrations in order to showcase what is possible:

- An [Interactive Playground](https://traineq.org/imgui_bundle_online/projects/imgui_bundle_playground/) where it is possible to run demos and edit their code (select examples in the top right corner, and click on "Run")
- A [Minimal HTML page](https://traineq.org/imgui_bundle_online/projects/min_bundle_pyodide_app/demo_heart.html) showcasing how to use it, with an extremely short [source code](https://traineq.org/imgui_bundle_online/projects/min_bundle_pyodide_app/demo_heart.source.txt)


### Discussion and related PR
 
This recipe requires a change inside pyodide/Makefile.envs (see technical note below: add -sMAX_WEBGL_VERSION=2).

A [related PR](https://github.com/pyodide/pyodide/pull/5708) was posted to the main pyodide repo, to add this flag.

The test for this new recipe will fail if this change is not applied.

### Technical Notes:

1. Build configuration for Pyodide: -sMAX_WEBGL_VERSION=2 

2. Link with SDL2 (fPIC): 

meta.yaml/build will trigger the build of SDL2 and libtml5 with -fPIC

3. Running the tests 
- the test need to be run via a browser (not via node). For example:
```bash
   pytest pyodide-recipes/packages/imgui-bundle --runtime chrome
```
