### PR TITLE
Add `pyodide-build` repository as a submodule

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          submodules: recursive
+          persist-credentials: false
 
       - name: Install Emscripten ccache
         run: |
@@ -244,6 +246,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+          persist-credentials: false
 
       - name: Cache conda
         uses: actions/cache@v4
@@ -316,6 +322,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          submodules: recursive
+          persist-credentials: false
 
       - name: Setup Mambaforge
         uses: conda-incubator/setup-miniconda@v3

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "pyodide-build"]
+	path = pyodide-build
+	url = https://github.com/pyodide/pyodide-build
+	branch = updates-for-scipy

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "pyodide-build"]
 	path = pyodide-build
 	url = https://github.com/pyodide/pyodide-build
-	branch = updates-for-scipy

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,13 +1,18 @@
 additionalRepositories:
   - url: https://github.com/emscripten-core/emsdk
+  - url: https://github.com/pyodide/pyodide-build
+    checkoutLocation: pyodide-build
 tasks:
+  - name: Sync submodule(s)
+    init: git submodule update --init --recursive
+    command: echo "Submodules initialized"
   - name: Setup
     init: |
       pyenv global system
       conda env create -f environment.yml
       conda activate pyodide-env
 
-      pip install git+https://github.com/pyodide/pyodide-build.git
+      pip install ./pyodide-build/
       pyodide xbuildenv install
 
       EMSCRIPTEN_VERSION=$(pyodide config get emscripten_version)

--- a/README.md
+++ b/README.md
@@ -4,13 +4,22 @@ Collections of package recipes for Pyodide
 
 ## Adding a new package
 
-> Note: Use Python 3.12 or upper to run the following commands.
+> Note: Use Python 3.13 or upper to run the following commands.
 
 To add a new package, create a package recipe in the `packages` directory.
-You can start by creating a boilerplate recipe with the following command:
+
+It is required to clone the repository with the `--recurse-submodules` option to ensure
+that all submodules are initialized. If hyou have already cloned the repository without
+this option, you can run the following command to initialize the submodules:
 
 ```bash
-$ pip install pyodide-build
+$ git submodule update --init --recursive
+```
+
+You can then start by creating a boilerplate recipe with the following command:
+
+```bash
+$ pip install ./pyodide-build
 $ pyodide skeleton pypi <package-name>
 ```
 

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -30,7 +30,7 @@ by updating the `Makefile.envs` file in the pyodide/pyodide repository.
 To build and test packages locally, you need to prepare the necessary tools and dependencies.
 
 - compatible Python version
-- pyodide-build
+- pyodide-build, which is provided by the `pyodide-build` Git submodule in the repository root
 - emscripten
 - selenium (for testing)
 
@@ -71,9 +71,9 @@ The `pyodide-recipes` repository is used to build packages for both stable and n
 We use different branches for those versions:
 
 - `main`: the default branch, used for nightly versions of Pyodide
-  - It uses nightly xbuildenv and nightly pyodide-build to build packages.
+  - It uses nightly xbuildenv and the pyodide-build submodule to build packages.
 - `<version>`: a branch for stable versions of Pyodide
-  - It uses stable xbuildenv and nightly (or stable if there is any breaking change) pyodide-build to build packages.
+  - It uses stable xbuildenv and pyodide-build submodule (or a stable version, if there are any breaking changes) to build packages.
 
 Let's say we have a stable Pyodide version `0.27.0`, and we are developing a new version `0.28.0`.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ pytest-httpserver
 pytest-benchmark
 auditwheel-emscripten
 pytest-asyncio
-pyodide-build
+./pyodide-build/
 zstandard
 brotli

--- a/tools/prepare_pyodide_build.sh
+++ b/tools/prepare_pyodide_build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-python -m pip install "git+https://github.com/pyodide/pyodide-build"
+python -m pip install ./pyodide-build/
 pyodide xbuildenv install


### PR DESCRIPTION
## Description

This PR adds `pyodide-build` as a submodule, just like it is the case in the Pyodide main/runtime repository. This has a few advantages:
- being able to test out changes to `pyodide-build` to assess breakages for new changes or compatibility with older changes
- being able to modify compilation routines such as `pywasmcross.py` to assess changes
- being able to test out ABI changes with new nightly xbuildenvs
- and so on

As we've pinned our Pyodide build environment in `pyproject.toml` in the repository root, this PR does not introduce any ABI or compilation-specific changes.


> [!NOTE]
> The note below has been resolved; the submodule points to https://github.com/pyodide/pyodide-build/commit/ee11882923d8e06e8164324fec5d225e4db3bbaf on the `main` branch now.

> [!TIP]
> ~The submodule checked in this PR builds upon my branch, which I've submitted as a PR at https://github.com/pyodide/pyodide-build/pull/213. Once merged, I shall update the submodule to point to `main`. Please review that PR first. Thank you!~

## PR stack

Please review the following PRs in the order listed below:

- https://github.com/pyodide/pyodide-build/pull/168
- https://github.com/pyodide/pyodide-build/pull/213
- https://github.com/pyodide/pyodide-recipes/pull/140 ➡️ **you are here**
- https://github.com/pyodide/pyodide-recipes/pull/141 