### PR TITLE
Fix builds for `libnetcdf` and `lxml` after #138

### DIFF
--- a/packages/libnetcdf/meta.yaml
+++ b/packages/libnetcdf/meta.yaml
@@ -13,7 +13,7 @@ source:
 requirements:
   host:
     - libhdf5
-    - zlib
+    - libzlib
     - libxml
 
 build:

--- a/packages/lxml/meta.yaml
+++ b/packages/lxml/meta.yaml
@@ -13,7 +13,7 @@ requirements:
   host:
     - libxml
     - libxslt
-    - zlib
+    - libzlib
     - libiconv
 test:
   imports:


### PR DESCRIPTION
This PR fixes the build job after `zlib` was renamed to `libzlib` in #138, as these two packages were missed as a part of the changed recipes calculation.

