### PR TITLE
Update taglib to 2.1.1

### DIFF
--- a/packages/taglib/meta.yaml
+++ b/packages/taglib/meta.yaml
@@ -1,22 +1,17 @@
 package:
   name: taglib
-  version: "2.1"
+  version: "2.1.1"
   tag:
     - library
     - shared_library
     - cmake
 source:
-  url: https://github.com/taglib/taglib/releases/download/v2.1/taglib-2.1.tar.gz
-  sha256: 95b788b39eaebab41f7e6d1c1d05ceee01a5d1225e4b6d11ed8976e96ba90b0c
+  url: https://github.com/taglib/taglib/releases/download/v2.1.1/taglib-2.1.1.tar.gz
+  sha256: 3716d31f7c83cbf17b67c8cf44dd82b2a2f17e6780472287a16823e70305ddba
 
 build:
   type: shared_library
   script: |
-    # utfcpp is a header-only library in a git submodule. Unfortunately,  it is missing in the release .tar.gz.
-    # Therefore, we need to download the commit referenced by the git submodule
-    # Commit id can be found here: https://github.com/taglib/taglib/tree/d48f02030d0d8eb94003da7213ea38e7aae6b422/3rdparty
-    wget -O utfcpp.tar.gz https://github.com/nemtrif/utfcpp/archive/df857efc5bbc2aa84012d865f7d7e9cccdc08562.tar.gz
-    tar -zxvf utfcpp.tar.gz -C 3rdparty/utfcpp/ --strip-components=1
     # See https://github.com/supermihi/pytaglib/blob/9e315c2b932d96fa54c2477a82747d0d9f211c87/build_native_taglib.py#L155-L167
     emcmake cmake \
       -DWITH_ZLIB=OFF \


### PR DESCRIPTION
Update taglib to 2.1.1. The utfcpp submodule is now included in the release tar file.