### PR TITLE
Fix builds for `libgmp` when building on macOS [full build]

### DIFF
--- a/packages/libgmp/meta.yaml
+++ b/packages/libgmp/meta.yaml
@@ -13,12 +13,15 @@ build:
   script: |
     emconfigure ./configure \
         CFLAGS="-fPIC" \
-        --disable-dependency-tracking \
-        --host none \
+        HOST_CC=$(which clang) \
+        --host=wasm32-unknown-emscripten \
+        --build=$(./config.guess) \
+        --disable-assembly \
         --disable-shared \
         --enable-static \
         --enable-cxx \
-        --prefix=${WASM_LIBRARY_DIR}
+        --prefix=${WASM_LIBRARY_DIR} \
+        ac_cv_prog_cc_cross=yes
     emmake make -j ${PYODIDE_JOBS:-3}
     emmake make install
 about:

--- a/packages/libgmp/meta.yaml
+++ b/packages/libgmp/meta.yaml
@@ -13,7 +13,7 @@ build:
   script: |
     emconfigure ./configure \
         CFLAGS="-fPIC" \
-        HOST_CC=$(which clang) \
+        CC_FOR_BUILD="cc" \
         --host=wasm32-unknown-emscripten \
         --build=$(./config.guess) \
         --disable-assembly \


### PR DESCRIPTION
This is a port of my previous PR at pyodide/pyodide#5662 to this repository. 

Apparently libgmp has an incorrectly configured configure file (likely!), which is why build failures don't show up on Linux builds, but I've had trouble compiling it to WASM on my macOS machine. This PR updates the recipe to set `HOST_CC` to clang (as `emsdk` can sometimes set it to Emscripten's Clang, which wouldn't work as a host compiler: https://github.com/emscripten-core/emscripten/issues/16358), sets both `--host` and `--build` triplets, and lastly, removes the deprecated` --disable-dependency-tracking` in favour of `--disable-assembly`. I've also `set ac_cv_prog_cc_cross=yes` to ensure that we always cross-compile.

Previously, while these changes resolved build issues for me on macOS, I encountered "permission denied" errors in CircleCI (Linux). We should examine if we see them here in GHA as well.