### PR TITLE
Bump urllib3 and requests

### DIFF
--- a/packages/requests/meta.yaml
+++ b/packages/requests/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: requests
-  version: 2.32.3
+  version: 2.32.4
   top-level:
     - requests
 source:
-  url: https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl
-  sha256: 70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6
+  url: https://files.pythonhosted.org/packages/py3/r/requests/requests-2.32.4-py3-none-any.whl
+  sha256: 27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c
 requirements:
   run:
     - charset-normalizer

--- a/packages/urllib3/meta.yaml
+++ b/packages/urllib3/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: urllib3
-  version: 2.3.0
+  version: 2.5.0
   top-level:
     - urllib3
 source:
-  url: https://files.pythonhosted.org/packages/aa/63/e53da845320b757bf29ef6a9062f5c669fe997973f966045cb019c3f4b66/urllib3-2.3.0.tar.gz
-  sha256: f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d
+  url: https://files.pythonhosted.org/packages/source/u/urllib3/urllib3-2.5.0.tar.gz
+  sha256: 3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760
 test:
   imports:
     - urllib3
@@ -13,5 +13,6 @@ test:
 about:
   home: https://github.com/urllib3/urllib3
   PyPI: https://pypi.org/project/urllib3
-  summary: HTTP library with thread-safe connection pooling, file post, and more.
+  summary: HTTP library with thread-safe connection pooling, file post, and
+    more.
   license: MIT


### PR DESCRIPTION
There was a CVE that affects urllib3 + Node.js. So version upgrade is required.

cc: @joemarshall 

https://github.com/pypa/pip/issues/13447