### PR TITLE
tests: import awkward-cpp Python binding

### DIFF
--- a/packages/awkward-cpp/meta.yaml
+++ b/packages/awkward-cpp/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   exports: requested
   backend-flags: |
-    cmake.define.CMAKE_BUILD_WITH_INSTALL_RPATH=ON
+    cmake.define.CMAKE_MODULE_LINKER_FLAGS=-Wl,-rpath=\$ORIGIN
     build.verbose=ON
 
 requirements:


### PR DESCRIPTION
This is broken (https://github.com/scikit-hep/awkward/issues/3572), so seeing if we can expose the issue. Will try updating (44 is old) next.

Also, the awkward (pure Python) version must work with the awkward-cpp version, so maybe it makes sense to ship that too so it resolves correctly.
