### PR TITLE
Pin pybind11 version for boost-histogram

### DIFF
--- a/packages/boost-histogram/meta.yaml
+++ b/packages/boost-histogram/meta.yaml
@@ -13,7 +13,7 @@ requirements:
     - numpy # runtime only
   constraint:
     # Fixed in https://github.com/scikit-hep/boost-histogram/pull/1024 I guess
-    - pybind<3
+    - pybind11<3
 about:
   home: https://github.com/scikit-hep/boost-histogram
   PyPI: https://pypi.org/project/boost-histogram

--- a/packages/boost-histogram/meta.yaml
+++ b/packages/boost-histogram/meta.yaml
@@ -11,6 +11,9 @@ source:
 requirements:
   run:
     - numpy # runtime only
+  constraint:
+    # Fixed in https://github.com/scikit-hep/boost-histogram/pull/1024 I guess
+    - pybind<3
 about:
   home: https://github.com/scikit-hep/boost-histogram
   PyPI: https://pypi.org/project/boost-histogram


### PR DESCRIPTION
boost-histogram tests have been failing starting from a week ago. I am guessing that it is because of new pybind11 major release.