### PR TITLE
Updated python-sat to version 1.8.dev19.

### DIFF
--- a/packages/python-sat/meta.yaml
+++ b/packages/python-sat/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: python-sat
-  version: 1.8.dev17
+  version: 1.8.dev19
   top-level:
     - pysat
 source:
-  sha256: 26f873f5fa2fe097fe37015856d09d798a363f32ad50042aa831cb696383bf31
-  url: https://files.pythonhosted.org/packages/e3/dd/b08843d57509c292cd7bd4a367f7dcc0c5b76edcece3fdc3c35426bfba6d/python-sat-1.8.dev17.tar.gz
+  sha256: b272f915cec08b89e3a477038492598bc9d34f1c22b1f33acc6cbd2aaf8538b3
+  url: https://files.pythonhosted.org/packages/72/56/81fcad52cc1cf47399500cb0062a00094897df1bb8847cf989aaf73afc76/python_sat-1.8.dev19.tar.gz
 
   patches:
     - patches/force_malloc.patch


### PR DESCRIPTION
The update includes
- a few performance improvements to the existing tools dealing with over-constrained systems (like RC2, LBX, Hitman, and OptUx),
- a pair of brand-new tools for compiling arbitrary Boolean formulas into Blake Canonical Form (Primer) and computing the smallest size CNF and DNF representation of arbitrary Boolean formulas (Bica),
- a few bug fixes in arbitrary Boolean formula creation and "clausification".