### PR TITLE
bump inspice

### DIFF
--- a/packages/inspice/meta.yaml
+++ b/packages/inspice/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: inspice
-  version: 1.6.3.3
+  version: 1.6.4.1
   top-level:
     - InSpice
 source:


### PR DESCRIPTION
Is there some automation to bump pypi packages?

This is only really here to test libngspice, and having it be outdated is unfortunate because it's a pure python package that could have just been installed from pypi