### PR TITLE
bilby.cython: remove bogus top level

### DIFF
--- a/packages/bilby.cython/meta.yaml
+++ b/packages/bilby.cython/meta.yaml
@@ -2,7 +2,6 @@ package:
   name: bilby.cython
   version: 0.5.3
   top-level:
-    - docs
     - bilby_cython
 source:
   url: https://files.pythonhosted.org/packages/source/b/bilby_cython/bilby_cython-0.5.3.tar.gz


### PR DESCRIPTION
@ryanking13 thanks for catching this extra. I think the numpy build dependency is needed (it is for conda), but I'm happy to try removing it if you like?