### PR TITLE
TST Fix package name parsing bug in conftest.py

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -19,7 +19,7 @@ def maybe_skip_test(item, delayed=False):
     skip_msg = None
     # Testing a package. Skip the test if the package is not built.
     match = re.match(
-        r".*/packages/(?P<name>[\w\-]+)/test_[\w\-]+\.py", str(item.parent.fspath)
+        r".*/packages/(?P<name>[\w\-\.]+)/test_[\w\-]+\.py", str(item.parent.fspath)
     )
     if match and not is_common_test:
         package_name = match.group("name")


### PR DESCRIPTION
Resolve #347

Our regex was not parsing the `.` in the package name correctly.