### PR TITLE
Update lakers-python to 0.6.0

### DIFF
--- a/packages/lakers-python/meta.yaml
+++ b/packages/lakers-python/meta.yaml
@@ -1,13 +1,13 @@
 package:
   name: lakers-python
-  version: 0.5.0
+  version: 0.6.0
   tag:
     - rust
   top-level:
     - lakers
 source:
-  url: https://files.pythonhosted.org/packages/7e/06/49defc46cb7cffd46daf06538bbd4f6dcf4da511036fbb73ea856a02def4/lakers_python-0.5.0.tar.gz
-  sha256: 19059fde5572409f061c3dfcaa12f1634572ff3622b45f81853d05bb67a37bc5
+  url: https://files.pythonhosted.org/packages/2a/e6/416be35d38c50af5475fa55324ef16f9e6f5039a750974f54da78f8fd3e6/lakers_python-0.6.0.tar.gz
+  sha256: fac63f3f5679a04d9277311c1f3e8eacee02a10e456547187f1a9695b6b3a333
 requirements:
   executable:
     - rustup


### PR DESCRIPTION
The change log in [the release commit](https://github.com/lake-rs/lakers/commit/dfb73f9e706a8ed0193b945def3fea7fc496350c) is a bit domain knowledge heavy; what the release does in non-EDHOC terms is that it improves standard compliance by allowing the processing of repeated protocol elements (which the standard requires).

There were no changes in how we use maturin there, so I'm leaving the Maturin constraint in place.