### PR TITLE
CI Release latest packages to `pyodide-nightly` package index.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -283,7 +283,7 @@ jobs:
           name: repodata
           path: ./repodata/
           retention-days: 7
-      
+
       - name: Store build logs
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -468,7 +468,7 @@ jobs:
         run: node scipy-pytest.js --pyargs scipy -m "not slow" -vra
         working-directory: packages/scipy/
 
-  release:
+  release: # deploy to pyodide channel
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -476,6 +476,45 @@ jobs:
     needs: [build]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     environment: deploy
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Setup Mambaforge
+        uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f # v3.2.0
+        with:
+          miniforge-variant: Miniforge3
+          miniforge-version: latest
+          activate-environment: pyodide-env
+          conda-remove-defaults: true
+          channels: conda-forge
+
+      - name: Download build artifact
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: repodata
+          path: ./repodata/
+
+      - name: Install anaconda-client
+        run: |
+          mamba install -c defaults anaconda-client -y
+
+      - name: Upload wheels
+        run: |
+          # Anaconda denies packages with long descriptions, so set summary to null
+          anaconda -t ${{ secrets.ANACONDA_API_TOKEN }} upload --force ./repodata/*.whl --summary=" " --description=" "
+
+  release-nightly:  # deploys to pyodide-nightly channel
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -el {0}
+    needs: [build]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    environment: deploy-nightly
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:

--- a/README.md
+++ b/README.md
@@ -30,6 +30,28 @@ and other metadata including the dependencies.
 See the [Pyodide documentation](https://pyodide.org/en/stable/development/adding-packages-into-pyodide-distribution.html)
 for more information on creating package recipes.
 
+## How to use the recipes in Pyodide
+
+There are three ways to use the packages built by this repository in Pyodide:
+
+### 1. Wait until the next Pyodide release
+
+When we release a new version of Pyodide, we include the updated recipes in the Pyodide distribution.
+But we don't guarantee that patch releases of Pyodide will include the updated recipes.
+
+### 2. Use Anaconda package index
+
+We also release the recipes to Anaconda package index. You can pass the following indesx URLs to `micropip` to install the packages
+from the index.
+
+- `https://pypi.anaconda.org/pyodide/simple`: Contains all the packages built for all stable versions of Pyodide since Pyodide 0.28.0.
+- `https://pypi.anaconda.org/pyodide-nightly/simple`: Contains the tip-of-tree packages which exist in the `main` branch of this repository.
+
+### 3. Download the release artifact from GitHub releases
+
+We release the built packages as a tarball in the GitHub releases occassionally.
+You can download the tarball and host it on your own server.
+
 ## Maintainer information
 
 See [MAINTAINERS.md](docs/MAINTAINERS.md) for information on how to maintain this repository.


### PR DESCRIPTION
I made another package index in anaconda package index, so we can push tip-of-tree packages in the main branch (see https://github.com/pyodide/pyodide/discussions/5897)