### PR TITLE
Add fastcan

### DIFF
--- a/packages/fastcan/meta.yaml
+++ b/packages/fastcan/meta.yaml
@@ -1,0 +1,22 @@
+package:
+  name: fastcan
+  version: 0.4.1
+  top-level:
+  - fastcan
+source:
+  url: https://files.pythonhosted.org/packages/source/f/fastcan/fastcan-0.4.1.tar.gz
+  sha256: a4d3b285671920ed413462a4a3536794f494cd4373501a68f6820e1ecb151fbe
+requirements:
+  run:
+    - scikit-learn
+test:
+  imports:
+    - fastcan
+about:
+  home: https://github.com/scikit-learn-contrib/fastcan
+  PyPI: https://pypi.org/project/fastcan
+  summary: A fast canonical-correlation-based greedy search algorithm
+  license: MIT
+extra:
+  recipe-maintainers:
+  - MatthewSZhang

--- a/packages/fastcan/test_fastcan.py
+++ b/packages/fastcan/test_fastcan.py
@@ -1,0 +1,12 @@
+import pytest
+from pytest_pyodide import run_in_pyodide
+
+
+@pytest.mark.driver_timeout(60)
+@run_in_pyodide(packages=["fastcan"])
+def test_fastcan():
+    from fastcan import FastCan
+    X = [[1, 0], [0, 1]]
+    y = [1, 0]
+    s = FastCan(verbose=0).fit(X, y).get_support()
+    assert (s == [True, False]).all()


### PR DESCRIPTION
fastcan: A fast canonical-correlation-based greedy search algorithm
homepage: https://fastcan.readthedocs.io/en/latest/
repository: https://github.com/scikit-learn-contrib/fastcan/
Language: Python, Cython, meson