### PR TITLE
Bump imgui-bundle to v1.92.4

### DIFF
--- a/packages/imgui-bundle/meta.yaml
+++ b/packages/imgui-bundle/meta.yaml
@@ -1,12 +1,12 @@
 package:
   name: imgui-bundle
-  version: 1.92.0
+  version: 1.92.4
   top-level:
     - imgui_bundle
 
 source:
-  url: https://github.com/pthom/imgui_bundle/releases/download/v1.92.0/srcs-full-v1.92.0.tar.gz
-  sha256: 359336ca8edeef3e1313652be86d4a3aacb28962f4906926ca0db3817c27fcdb
+  url: https://github.com/pthom/imgui_bundle/releases/download/v1.92.4/srcs-full-v1.92.4.tar.gz
+  sha256: c53afb7fb410c12f9727ce504b61125d048f60aeb6ca0d50ccbb395c40ccd3c8
 
 build:
   # imgui-bundle needs to link with relocatable versions of SDL2 and html5.


### PR DESCRIPTION
This bumps imgui-bundle to v1.92.4

I am the author of ImGui Bundle. 

I just tested this package under pyodide and my test showed that this new version works.

Thanks!