### PR TITLE
Revert numpy version to 2.2.5 until we update Scipy

### DIFF
--- a/packages/numpy-tests/meta.yaml
+++ b/packages/numpy-tests/meta.yaml
@@ -1,13 +1,13 @@
 package:
   name: numpy-tests
-  version: 2.3.1
+  version: 2.2.5
   tag:
     - min-scipy-stack
   top-level:
     - numpy
 # NOTE: keep in sync with numpy/meta.yaml
 source:
-  path: ../numpy/build/numpy-2.3.1
+  path: ../numpy/build/numpy-2.2.5
 
 build:
   unvendor-tests: false # we do this on our own using Meson's install tags

--- a/packages/numpy/meta.yaml
+++ b/packages/numpy/meta.yaml
@@ -1,14 +1,15 @@
-# NOTE: keep the name, version, and other fields in sync with source/path in numpy-tests/meta.yaml.
 package:
   name: numpy
-  version: 2.3.1
+  version: 2.2.5
   tag:
     - min-scipy-stack
   top-level:
     - numpy
 source:
-  url: https://files.pythonhosted.org/packages/source/n/numpy/numpy-2.3.1.tar.gz
-  sha256: 1ec9ae20a4226da374362cca3c62cd753faf2f951440b0e3b98e93c235441d2b
+  url: https://files.pythonhosted.org/packages/source/n/numpy/numpy-2.2.5.tar.gz
+  sha256: a9c0d994680cd991b1cb772e8b297340085466a6fe964bc9d4e80f5e2f43c291
+  patches:
+    - patches/0001-TST-Prevent-import-error-when-tests-are-not-included.patch
 
 build:
   unvendor-tests: false # we do this on our own using Meson's install tags
@@ -17,7 +18,6 @@ build:
     setup-args=-Dallow-noblas=true
     setup-args=--cross-file=${MESON_CROSS_FILE}
     install-args=--tags=runtime,python-runtime,devel
-    build-dir=build
   # numpy creates numpy/distutils/__pycache__ directory during the build.
   # It breaks our test because there is a .pyc in the directory.
   post: |

--- a/packages/numpy/patches/0001-TST-Prevent-import-error-when-tests-are-not-included.patch
+++ b/packages/numpy/patches/0001-TST-Prevent-import-error-when-tests-are-not-included.patch
@@ -1,0 +1,71 @@
+From 8b298aa6f666449fff1844253cd6e0be5fbf3612 Mon Sep 17 00:00:00 2001
+From: ryanking13 <def6488@gmail.com>
+Date: Sun, 11 May 2025 11:05:05 +0900
+Subject: [PATCH 1/1] TST: Prevent import error when tests are not included in
+
+https://github.com/numpy/numpy/pull/28936
+
+---
+ numpy/_core/tests/_natype.py    | 7 +++++++
+ numpy/conftest.py               | 4 ++--
+ numpy/testing/_private/utils.py | 9 ---------
+ 3 files changed, 9 insertions(+), 11 deletions(-)
+
+diff --git a/numpy/_core/tests/_natype.py b/numpy/_core/tests/_natype.py
+index e529e548cf..86eb68801d 100644
+--- a/numpy/_core/tests/_natype.py
++++ b/numpy/_core/tests/_natype.py
+@@ -196,3 +196,10 @@ def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+ 
+ 
+ pd_NA = NAType()
++
++def get_stringdtype_dtype(na_object, coerce=True):
++    # explicit is check for pd_NA because != with pd_NA returns pd_NA
++    if na_object is pd_NA or na_object != "unset":
++        return np.dtypes.StringDType(na_object=na_object, coerce=coerce)
++    else:
++        return np.dtypes.StringDType(coerce=coerce)
+\ No newline at end of file
+diff --git a/numpy/conftest.py b/numpy/conftest.py
+index 0eb42d1103..5105b43b03 100644
+--- a/numpy/conftest.py
++++ b/numpy/conftest.py
+@@ -14,8 +14,8 @@
+ import numpy as np
+ 
+ from numpy._core._multiarray_tests import get_fpu_mode
+-from numpy._core.tests._natype import pd_NA
+-from numpy.testing._private.utils import NOGIL_BUILD, get_stringdtype_dtype
++from numpy._core.tests._natype import pd_NA, get_stringdtype_dtype
++from numpy.testing._private.utils import NOGIL_BUILD
+ 
+ try:
+     from scipy_doctest.conftest import dt_config
+diff --git a/numpy/testing/_private/utils.py b/numpy/testing/_private/utils.py
+index 42e43e21f3..a1a6f4f1ff 100644
+--- a/numpy/testing/_private/utils.py
++++ b/numpy/testing/_private/utils.py
+@@ -28,7 +28,6 @@
+ from numpy import isfinite, isnan, isinf
+ import numpy.linalg._umath_linalg
+ from numpy._utils import _rename_parameter
+-from numpy._core.tests._natype import pd_NA
+ 
+ from io import StringIO
+ 
+@@ -2750,11 +2749,3 @@ def run_threaded(func, max_workers=8, pass_count=False,
+                     barrier.abort()
+             for f in futures:
+                 f.result()
+-
+-
+-def get_stringdtype_dtype(na_object, coerce=True):
+-    # explicit is check for pd_NA because != with pd_NA returns pd_NA
+-    if na_object is pd_NA or na_object != "unset":
+-        return np.dtypes.StringDType(na_object=na_object, coerce=coerce)
+-    else:
+-        return np.dtypes.StringDType(coerce=coerce)
+-- 
+2.29.2.windows.2
+

--- a/packages/numpy/test_numpy.py
+++ b/packages/numpy/test_numpy.py
@@ -175,15 +175,15 @@ def test_python2js_numpy_scalar(selenium, dtype):
 
 
 @pytest.mark.skip_pyproxy_check
-def test_runpythonasync_numpy(selenium):
-    selenium.run_async(
+def test_runpythonasync_numpy(selenium_standalone):
+    selenium_standalone.run_async(
         """
         import numpy as np
         x = np.zeros(5)
         """
     )
     for i in range(5):
-        assert selenium.run_js(
+        assert selenium_standalone.run_js(
             f"return pyodide.globals.get('x').toJs()[{i}] == 0"
         )
 

--- a/packages/numpy/test_numpy.py
+++ b/packages/numpy/test_numpy.py
@@ -175,15 +175,15 @@ def test_python2js_numpy_scalar(selenium, dtype):
 
 
 @pytest.mark.skip_pyproxy_check
-def test_runpythonasync_numpy(selenium_standalone):
-    selenium_standalone.run_async(
+def test_runpythonasync_numpy(selenium):
+    selenium.run_async(
         """
         import numpy as np
         x = np.zeros(5)
         """
     )
     for i in range(5):
-        assert selenium_standalone.run_js(
+        assert selenium.run_js(
             f"return pyodide.globals.get('x').toJs()[{i}] == 0"
         )
 


### PR DESCRIPTION
@agriyakhetarpal I would like to revert numpy version to 2.2.5 until we figure out how to fix #141. Having different numpy version in the 0.29 branch and the main branch is a bit annoying and easy to make mistake.