### PR TITLE
ci: add test summary using JUnitXML (#346)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -382,7 +382,25 @@ jobs:
             -n $(nproc) \
             --runner=${{ matrix.test-config.runner }} \
             --rt ${{ matrix.test-config.runtime }} \
+            --junitxml=test-results-${{ matrix.test-config.runtime }}.xml \
             packages
+
+      - name: Surface failing tests
+        if: always()
+        uses: pmeier/pytest-results-action@v0.7.2
+        with:
+          path: test-results-${{ matrix.test-config.runtime }}.xml
+          summary: true  # 전체 테스트 결과 요약 표시
+          display-options: fE  # 상세 내용은 실패(f)와 에러(E)만 표시
+          fail-on-empty: true
+          title: "Test Results - ${{ matrix.test-config.runtime }}"
+
+      - name: Upload test results XML
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ matrix.test-config.runtime }}
+          path: test-results-${{ matrix.test-config.runtime }}.xml
+        if: always()
 
   # This job runs the SciPy tests with Node.js based on the
   # above checks; separate from the main test job.
@@ -466,8 +484,27 @@ jobs:
           mv packages/scipy/scipy-conftest.py packages/scipy/conftest.py
 
       - name: Run SciPy test suite
-        run: node scipy-pytest.js --pyargs scipy -m "not slow" -vra
+        run: node scipy-pytest.js --pyargs scipy -m "not slow" -vra --junitxml=test-results-scipy.xml
         working-directory: packages/scipy/
+
+      - name: Parse SciPy test results
+        id: parse_scipy_test_results
+        run: |
+          if [ -f packages/scipy/test-results-scipy.xml ]; then
+            python tools/parse_test_result.py packages/scipy/test-results-scipy.xml scipy > test-summary-scipy.md
+            echo "SCIPY_TEST_SUMMARY_CREATED=true" >> $GITHUB_ENV
+          else
+            echo "No SciPy test results XML found"
+            echo "SCIPY_TEST_SUMMARY_CREATED=false" >> $GITHUB_ENV
+          fi
+
+      - name: Store SciPy test summary
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: github.event_name == 'pull_request' && env.SCIPY_TEST_SUMMARY_CREATED == 'true'
+        with:
+          name: test-summary-scipy
+          path: test-summary-scipy.md
+          retention-days: 7
 
   release: # deploy to pyodide channel
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -390,8 +390,8 @@ jobs:
         uses: pmeier/pytest-results-action@v0.7.2
         with:
           path: test-results-${{ matrix.test-config.runtime }}.xml
-          summary: true  # 전체 테스트 결과 요약 표시
-          display-options: fE  # 상세 내용은 실패(f)와 에러(E)만 표시
+          summary: true  # Always display overall test statistics summary
+          display-options: fE  # Show detailed list only for failed (f) and error (E) tests
           fail-on-empty: true
           title: "Test Results - ${{ matrix.test-config.runtime }}"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -387,7 +387,7 @@ jobs:
 
       - name: Surface failing tests
         if: always()
-        uses: pmeier/pytest-results-action@v0.7.2
+        uses: pmeier/pytest-results-action@20b595761ba9bf89e115e875f8bc863f913bc8ad # v0.7.2
         with:
           path: test-results-${{ matrix.test-config.runtime }}.xml
           summary: true  # Always display overall test statistics summary
@@ -396,7 +396,7 @@ jobs:
           title: "Test Results - ${{ matrix.test-config.runtime }}"
 
       - name: Upload test results XML
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: test-results-${{ matrix.test-config.runtime }}
           path: test-results-${{ matrix.test-config.runtime }}.xml
@@ -484,27 +484,9 @@ jobs:
           mv packages/scipy/scipy-conftest.py packages/scipy/conftest.py
 
       - name: Run SciPy test suite
-        run: node scipy-pytest.js --pyargs scipy -m "not slow" -vra --junitxml=test-results-scipy.xml
+        run: node scipy-pytest.js --pyargs scipy -m "not slow" -vra
         working-directory: packages/scipy/
 
-      - name: Parse SciPy test results
-        id: parse_scipy_test_results
-        run: |
-          if [ -f packages/scipy/test-results-scipy.xml ]; then
-            python tools/parse_test_result.py packages/scipy/test-results-scipy.xml scipy > test-summary-scipy.md
-            echo "SCIPY_TEST_SUMMARY_CREATED=true" >> $GITHUB_ENV
-          else
-            echo "No SciPy test results XML found"
-            echo "SCIPY_TEST_SUMMARY_CREATED=false" >> $GITHUB_ENV
-          fi
-
-      - name: Store SciPy test summary
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: github.event_name == 'pull_request' && env.SCIPY_TEST_SUMMARY_CREATED == 'true'
-        with:
-          name: test-summary-scipy
-          path: test-summary-scipy.md
-          retention-days: 7
 
   release: # deploy to pyodide channel
     runs-on: ubuntu-latest

--- a/.github/workflows/comment-test-summary.yml
+++ b/.github/workflows/comment-test-summary.yml
@@ -1,0 +1,141 @@
+name: Comment Test Summary
+
+on:
+  workflow_run:
+    workflows: ["Build Recipes"]
+    types:
+      - completed
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  download:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.event == 'pull_request' }}
+    steps:
+      - name: 'Download test summary artifacts'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            
+            // Find all test summary artifacts
+            let testSummaryArtifacts = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name.startsWith("test-summary-");
+            });
+            
+            if (testSummaryArtifacts.length === 0) {
+              console.log("No test summary artifacts found");
+              return;
+            }
+            
+            const fs = require('fs');
+            const path = require('path');
+            const temp = '${{ runner.temp }}/test-artifacts';
+            
+            if (!fs.existsSync(temp)){
+              fs.mkdirSync(temp);
+            }
+            
+            // Download all test summary artifacts
+            for (let artifact of testSummaryArtifacts) {
+              let download = await github.rest.actions.downloadArtifact({
+                 owner: context.repo.owner,
+                 repo: context.repo.repo,
+                 artifact_id: artifact.id,
+                 archive_format: 'zip',
+              });
+              
+              const artifactPath = path.join(temp, `${artifact.name}.zip`);
+              fs.writeFileSync(artifactPath, Buffer.from(download.data));
+              console.log(`Downloaded artifact: ${artifact.name}`);
+            }
+
+      - name: 'Unzip test summary artifacts'
+        run: |
+          cd "${{ runner.temp }}/test-artifacts"
+          for zip in *.zip; do
+            if [ -f "$zip" ]; then
+              unzip "$zip" -d "${zip%.zip}"
+              echo "Unzipped: $zip"
+            fi
+          done
+
+      - name: 'Comment test summary on PR'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const temp = '${{ runner.temp }}/test-artifacts';
+            
+            // Get PR number from the workflow run
+            const prNumber = context.payload.workflow_run.pull_requests[0]?.number;
+            if (!prNumber) {
+              console.log("No PR number found in workflow run");
+              return;
+            }
+            
+            // Collect all test summary files
+            let allSummaries = [];
+            const artifactDirs = fs.readdirSync(temp).filter(item => {
+              return fs.statSync(path.join(temp, item)).isDirectory();
+            });
+            
+            for (let dir of artifactDirs) {
+              const summaryFile = path.join(temp, dir, `${dir}.md`);
+              if (fs.existsSync(summaryFile)) {
+                const content = fs.readFileSync(summaryFile, 'utf8');
+                allSummaries.push(content);
+                console.log(`Found test summary: ${dir}`);
+              }
+            }
+            
+            if (allSummaries.length === 0) {
+              console.log("No test summary files found");
+              return;
+            }
+            
+            // Combine all summaries
+            const combinedSummary = allSummaries.join('\n\n---\n\n');
+            const finalComment = `# 🧪 Test Results Summary\n\n${combinedSummary}`;
+            
+            // Search for existing test summary comments
+            const comments = await github.rest.issues.listComments({
+              issue_number: prNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            });
+            
+            // Look for a comment that was created by the GitHub Actions bot and contains test summary
+            const testSummaryComment = comments.data.find(comment => 
+              comment.user.login === 'github-actions[bot]' && 
+              comment.body.includes('🧪 Test Results Summary')
+            );
+            
+            if (testSummaryComment) {
+              // Update existing comment
+              await github.rest.issues.updateComment({
+                comment_id: testSummaryComment.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: finalComment
+              });
+              console.log(`Updated existing test summary comment ID: ${testSummaryComment.id}`);
+            } else {
+              // Create new comment
+              await github.rest.issues.createComment({
+                issue_number: prNumber,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: finalComment
+              });
+              console.log('Created new test summary comment');
+            }


### PR DESCRIPTION
Purpose:

- Add a FAILED-only test summary to CI to quickly spot failing tests.
- Resolves  [[#346](https://github.com/pyodide/pyodide-recipes/issues/346)](https://github.com/pyodide/pyodide-recipes/issues/346).

Changes:

- `build.yml`: add pytest JUnitXML output, integrate `pmeier/pytest-results-action@v0.7.2`, upload artifacts
- Use third-party action’s summary generator instead of custom parser
- Show overall stats and only failed or error tests (`display-options: fE`)
- Store per-job JUnitXML as artifacts (`test-results-chrome`, `test-results-firefox`, `test-results-node`)

Test plan:

- Verified in fork with 14 CI jobs across Chrome, Firefox, and Node
- Added dummy failing tests in several packages: numpy, pandas, scipy, matplotlib, geopandas
- Confirmed that JUnitXML files are generated for each matrix
- Confirmed that artifacts (`test-results-*.xml`) are uploaded correctly
- Confirmed that summary tables are visible in GitHub Actions UI (passed, skipped, failed, error)
- Confirmed that only failed and error tests are listed with inline messages
- Confirmed that results are consistent across all environments (see attached screenshot)

References:

- [`[pmeier/pytest-results-action](https://github.com/pmeier/pytest-results-action)`](https://github.com/pmeier/pytest-results-action) for summary generation
- [[pytest JUnitXML documentation](https://docs.pytest.org/en/stable/how-to/output.html#creating-junitxml-format-files)](https://docs.pytest.org/en/stable/how-to/output.html#creating-junitxml-format-files) for XML export configuration
- CircleCI JUnitXML viewer used as reference for target UI


<img width="909" height="800" alt="스크린샷 2025-10-04 오후 3 59 35" src="https://github.com/user-attachments/assets/7278119f-af61-445c-a998-6348412b8997" />
<img width="902" height="181" alt="스크린샷 2025-10-04 오후 4 00 04" src="https://github.com/user-attachments/assets/e540ba73-f875-4519-b707-c5e51c1c5926" />
<img width="873" height="796" alt="스크린샷 2025-10-04 오후 3 59 55" src="https://github.com/user-attachments/assets/699b2e75-bc4c-4d50-aa8f-1b95fb394f05" />
<img width="892" height="509" alt="스크린샷 2025-10-04 오후 3 59 47" src="https://github.com/user-attachments/assets/d26b4172-6ae6-4d33-a341-4698d283423f" />

