### PR TITLE
Replace other gnu FTP URLs to mirror

### DIFF
--- a/packages/libglpk/meta.yaml
+++ b/packages/libglpk/meta.yaml
@@ -6,7 +6,7 @@ package:
     - static_library
 source:
   sha256: 4a1013eebb50f728fc601bdd833b0b2870333c3b3e5a816eeba921d95bec6f15
-  url: https://ftp.gnu.org/gnu/glpk/glpk-5.0.tar.gz
+  url: https://github.com/ryanking13/lib-mirror/releases/download/1.0.0/glpk-5.0.tar.gz
 
 build:
   type: static_library

--- a/packages/libgsl/meta.yaml
+++ b/packages/libgsl/meta.yaml
@@ -6,7 +6,7 @@ package:
     - static_library
 source:
   sha256: efbbf3785da0e53038be7907500628b466152dbc3c173a87de1b5eba2e23602b
-  url: https://ftp.gnu.org/gnu/gsl/gsl-2.7.tar.gz
+  url: https://github.com/ryanking13/lib-mirror/releases/download/1.0.0/gsl-2.7.tar.gz
 build:
   type: static_library
   script: |

--- a/packages/libiconv/meta.yaml
+++ b/packages/libiconv/meta.yaml
@@ -5,7 +5,7 @@ package:
     - library
     - static_library
 source:
-  url: https://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.16.tar.gz
+  url: https://github.com/ryanking13/lib-mirror/releases/download/1.0.0/libiconv-1.16.tar.gz
   sha256: e6a1b1b589654277ee790cce3734f07876ac4ccfaecbee8afa0b649cf529cc04
 
 build:

--- a/packages/libmpc/meta.yaml
+++ b/packages/libmpc/meta.yaml
@@ -5,7 +5,7 @@ package:
     - library
     - static_library
 source:
-  url: https://ftp.gnu.org/gnu/mpc/mpc-1.3.1.tar.gz
+  url: https://github.com/ryanking13/lib-mirror/releases/download/1.0.0/mpc-1.3.1.tar.gz
   sha256: ab642492f5cf882b74aa0cb730cd410a81edcdbec895183ce930e706c1c759b8
 
 requirements:

--- a/packages/libmpfr/meta.yaml
+++ b/packages/libmpfr/meta.yaml
@@ -5,7 +5,7 @@ package:
     - library
     - static_library
 source:
-  url: https://ftp.gnu.org/gnu/mpfr/mpfr-4.2.1.tar.xz
+  url: https://github.com/ryanking13/lib-mirror/releases/download/1.0.0/mpfr-4.2.1.tar.xz
   sha256: 277807353a6726978996945af13e52829e3abd7a9a5b7fb2793894e18f1fcbb2
 
 requirements:


### PR DESCRIPTION
Changes other GNU FTP urls to my mirror as well. I guess they are blocking GHA somehow.