### PR TITLE
Add msgpack-white package

### DIFF
--- a/packages/msgpack-white/meta.yaml
+++ b/packages/msgpack-white/meta.yaml
@@ -1,0 +1,16 @@
+package:
+  name: msgpack-white
+  version: 1.0.0
+  top-level:
+    - msgpack_white
+source:
+  url: https://files.pythonhosted.org/packages/source/m/msgpack_white/msgpack_white-1.0.0.tar.gz
+  sha256: 3c6431a567eda360e66b4a581d55ffc557eea374f130a3ef7da38f8bbdb74b81
+about:
+  home: null
+  PyPI: https://pypi.org/project/msgpack-white
+  summary: Determine the end of MessagePack data quickly
+  license: BSD-3-Clause
+extra:
+  recipe-maintainers:
+    - sometimes-i-send-pull-requests

--- a/packages/msgpack-white/test_msgpack_white.py
+++ b/packages/msgpack-white/test_msgpack_white.py
@@ -1,0 +1,16 @@
+from pytest_pyodide import run_in_pyodide
+
+
+@run_in_pyodide(packages=["msgpack-white", "pytest"])
+def test_msgpack_white(selenium):
+    import msgpack_white
+    import pytest
+
+    w = msgpack_white.White()
+
+    # msgpack.dumps({'x': 1}) ==> 81 A1 78 01
+    # msgpack.dumps(True)     ==> C3
+    assert w.feed(b"\x81\xA1") is None
+    assert w.feed(b"\x78\x01\xC3") == 2
+    with pytest.raises(ValueError, match="Invalid MessagePack message"):
+        w.feed(b"\xC1")


### PR DESCRIPTION
This package contains a C extension, so micropip can't install it directly from PyPI, hence packaging it here for use in Pyodide.  A short test of basic functionality is included.