### PR TITLE
Sync OpenBLAS SIMD recipe from main pyodide repo

### DIFF
--- a/packages/libopenblas/meta.yaml
+++ b/packages/libopenblas/meta.yaml
@@ -31,11 +31,19 @@ build:
     sed -ri 's@int ([cz](dotc|dotu|ladiv))@void \1@g' lapack-netlib/SRC/*.c\
         lapack-netlib/SRC/DEPRECATED/*.c
 
-    emmake make libs shared CC=emcc HOSTCC=gcc TARGET=RISCV64_GENERIC NOFORTRAN=1 NO_LAPACKE=1 \
-        USE_THREAD=0 LDFLAGS="${SIDE_MODULE_LDFLAGS}"
+    emmake make libs shared \
+        CC="emcc -msimd128" \
+        HOSTCC=gcc \
+        TARGET=RISCV64_GENERIC \
+        NOFORTRAN=1 NO_LAPACKE=1 \
+        USE_THREAD=0 \
+        LDFLAGS="${SIDE_MODULE_LDFLAGS}"
     mkdir -p dist
+
     # Add libf2c symbols to libopenblas.so
-    emcc ${WASM_LIBRARY_DIR}/lib/libf2c.a libopenblas.a ${SIDE_MODULE_LDFLAGS} \
+    emcc ${WASM_LIBRARY_DIR}/lib/libf2c.a libopenblas.a \
+        ${SIDE_MODULE_LDFLAGS} \
+        -msimd128 \
         -o libopenblas.so
 
     cp libopenblas.so dist


### PR DESCRIPTION
This PR applies the same SIMD-enabled OpenBLAS recipe update as in pyodide/pyodide#5960.