### PR TITLE
Remove top level import from numpy-tests

### DIFF
--- a/packages/numpy-tests/meta.yaml
+++ b/packages/numpy-tests/meta.yaml
@@ -3,8 +3,6 @@ package:
   version: 2.2.5
   tag:
     - min-scipy-stack
-  top-level:
-    - numpy
 # NOTE: keep in sync with numpy/meta.yaml
 source:
   path: ../numpy/build/numpy-2.2.5


### PR DESCRIPTION
Fixes https://github.com/pyodide/pyodide/issues/5978