### PR TITLE
Remove STDLIB_MODULE_CFLAGS usage

### DIFF
--- a/packages/hashlib/meta.yaml
+++ b/packages/hashlib/meta.yaml
@@ -14,7 +14,8 @@ build:
     tar -xf Python-${PYVERSION}.tgz
     cd Python-${PYVERSION}
 
-    emcc $STDLIB_MODULE_CFLAGS -c Modules/_hashopenssl.c -o _hashlib.o \
+    
+    emcc $SIDE_MODULE_CFLAGS -I Include/ -I. -IInclude/internal/ -c Modules/_hashopenssl.c -o _hashlib.o \
       $(pkg-config --cflags --dont-define-prefix libcrypto) -DOPENSSL_THREADS
 
     emcc _hashlib.o -o _hashlib.so $SIDE_MODULE_LDFLAGS \

--- a/packages/lzma/meta.yaml
+++ b/packages/lzma/meta.yaml
@@ -15,7 +15,7 @@ build:
     tar -xf Python-${PYVERSION}.tgz
     cd Python-${PYVERSION}
 
-    emcc $STDLIB_MODULE_CFLAGS -c Modules/_lzmamodule.c -o _lzmamodule.o \
+    emcc $SIDE_MODULE_CFLAGS -I Include/ -I. -IInclude/internal/ -c Modules/_lzmamodule.c -o _lzmamodule.o \
       $(pkg-config --cflags --dont-define-prefix liblzma)
 
     emcc _lzmamodule.o -o _lzma.so $SIDE_MODULE_LDFLAGS \

--- a/packages/sqlite3/meta.yaml
+++ b/packages/sqlite3/meta.yaml
@@ -30,7 +30,7 @@ build:
     embuilder build sqlite3 --pic
 
     for file in "${FILES[@]}"; do
-      emcc $STDLIB_MODULE_CFLAGS -c "${file}" -o "${file/.c/.o}"  \
+      emcc $SIDE_MODULE_CFLAGS -I Include/ -I. -IInclude/internal/ -c "${file}" -o "${file/.c/.o}"  \
         -sUSE_SQLITE3 -DMODULENAME=sqlite
     done
 


### PR DESCRIPTION
I would like to remove this from [pyodide-build](https://github.com/pyodide/pyodide-build/blob/53ae14be1db8361109b7a15e6c8486a84baeb05e/pyodide_build/config.py#L258C64-L258C99) as it is not useful for the end users.