### PR TITLE
matplotlib-inline 0.2.1, remove matplotlib dependency

### DIFF
--- a/packages/matplotlib-inline/meta.yaml
+++ b/packages/matplotlib-inline/meta.yaml
@@ -1,12 +1,12 @@
 package:
   name: matplotlib-inline
-  version: 0.1.7
+  version: 0.2.1
 requirements:
   run:
     - traitlets
 source:
-  url: https://files.pythonhosted.org/packages/8f/8e/9ad090d3553c280a8060fbf6e24dc1c0c29704ee7d1c372f0c174aa59285/matplotlib_inline-0.1.7-py3-none-any.whl
-  sha256: df192d39a4ff8f21b1895d72e6a13f5fcc5099f00fa84384e0ea28c2cc0653ca
+  url: https://files.pythonhosted.org/packages/af/33/ee4519fa02ed11a94aef9559552f3b17bb863f2ecfe1a35dc7f548cde231/matplotlib_inline-0.2.1-py3-none-any.whl
+  sha256: d56ce5156ba6085e00a9d54fead6ed29a9c47e215cd1bba2e976ef39f5710a76
 about:
   home: https://github.com/ipython/matplotlib-inline
   PyPI: https://pypi.org/project/matplotlib-inline


### PR DESCRIPTION
Thanks for maintaining this!

Changes:
- [x] update to `matplotlib-inline 0.2.1`
- [x] remove the `run` dependency on `matplotlib` 
  - despite the name, `matplotlib-inline` [_doesn't_ depend on `matplotlib`](https://github.com/ipython/matplotlib-inline/blob/0.2.1/pyproject.toml#L34), and not every interactive session needs that big package (and `numpy`, and...) every time.
