### PR TITLE
Add version constraint for cysignals

### DIFF
--- a/packages/pplpy/meta.yaml
+++ b/packages/pplpy/meta.yaml
@@ -14,6 +14,9 @@ requirements:
   run:
     - gmpy2
     - cysignals
+  constraint:
+    # ImportError: cysignals.signals does not export expected C function _do_raise_exception
+    - cysignals < 1.12.6
 build:
   cxxflags: |
     -std=c++11


### PR DESCRIPTION
Added a constraint on cysignals version to avoid ImportError.

Same as: https://github.com/pyodide/pyodide-recipes/pull/430