### PR TITLE
CI Do not overwrite wheels by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -525,7 +525,7 @@ jobs:
       - name: Upload wheels
         run: |
           # Anaconda denies packages with long descriptions, so set summary to null
-          anaconda -t ${{ secrets.ANACONDA_API_TOKEN }} upload --force ./repodata/*.whl --summary=" " --description=" "
+          anaconda -t ${{ secrets.ANACONDA_API_TOKEN }} upload ./repodata/*.whl --summary=" " --description=" "
 
   release-nightly:  # deploys to pyodide-nightly channel
     runs-on: ubuntu-latest
@@ -564,4 +564,4 @@ jobs:
       - name: Upload wheels
         run: |
           # Anaconda denies packages with long descriptions, so set summary to null
-          anaconda -t ${{ secrets.ANACONDA_API_TOKEN }} upload --force ./repodata/*.whl --summary=" " --description=" "
+          anaconda -t ${{ secrets.ANACONDA_API_TOKEN }} upload ./repodata/*.whl --summary=" " --description=" "

--- a/packages/pyarrow/meta.yaml
+++ b/packages/pyarrow/meta.yaml
@@ -9,7 +9,7 @@ source:
   # however, we are not building from source in CI to save time as it takes a long time to build.
   # TODO: upstream the build script to arrow so we don't need to maintain it here.
   url: https://anaconda.org/pyodide/pyarrow/22.0.0/download/pyarrow-22.0.0-cp313-cp313-pyodide_2025_0_wasm32.whl
-  sha256: 79e051fd57d25ff08e46250eb149e61aba1b6a0498ef12e75e1524fd258105de
+  sha256: c12e597efd26eea44ae6eca2d6e9b87064f0e011ecfb10a97c9ead896f1a7473
 about:
   home: https://arrow.apache.org/
   PyPI: https://pypi.org/project/pyarrow


### PR DESCRIPTION
I am uploading the wheels to Anaconda each time after building the pcakge, but it looks like if we overwrite it, the sha256 checksum changes (probably because we unpack/repack the the wheel). This changes this behavior so that we always get the same hash for the same version.