### PR TITLE
Add python-flirt package

### DIFF
--- a/packages/python-flirt/meta.yaml
+++ b/packages/python-flirt/meta.yaml
@@ -1,0 +1,23 @@
+package:
+  name: python-flirt
+  version: 0.9.10
+  tag:
+    - rust
+  top-level:
+    - flirt
+source:
+  url: https://files.pythonhosted.org/packages/source/p/python_flirt/python_flirt-0.9.10.tar.gz
+  sha256: a04c7be382631abbb763185b628fe7a5db9d6a8e36cd6fbc974e37f9669a3ffe
+requirements:
+  executable:
+    - rustup
+about:
+  home: https://github.com/williballenthin/lancelot/tree/master/pyflirt
+  PyPI: https://pypi.org/project/python-flirt
+  summary:
+    A Python library for parsing, compiling, and matching Fast Library Identification
+    and Recognition Technology (FLIRT) signatures.
+  license: Apache-2.0
+extra:
+  recipe-maintainers:
+    - nightlark

--- a/packages/python-flirt/test_python_flirt.py
+++ b/packages/python-flirt/test_python_flirt.py
@@ -1,0 +1,44 @@
+from pytest_pyodide import run_in_pyodide
+
+
+@run_in_pyodide(packages=["python-flirt"])
+def test_python_flirt(selenium):
+    import flirt
+
+    BUF = bytes([
+        # utcutil.dll
+        #  MD5 abc9ea116498feb8f1de45f60d595af6
+        #  SHA-1 2f1ba350237b74c454caf816b7410490f5994c59
+        #  SHA-256 7607897638e9dae406f0840dbae68e879c3bb2f08da350c6734e4e2ef8d61ac2
+        # __EH_prolog3_catch_align
+
+        0x51,0x8b,0x4c,0x24,0x0c,0x89,0x5c,0x24,0x0c,0x8d,0x5c,0x24,0x0c,0x50,0x8d,0x44,
+        0x24,0x08,0xf7,0xd9,0x23,0xc1,0x8d,0x60,0xf8,0x8b,0x43,0xf0,0x89,0x04,0x24,0x8b,
+        0x43,0xf8,0x50,0x8b,0x43,0xfc,0x8b,0x4b,0xf4,0x89,0x6c,0x24,0x0c,0x8d,0x6c,0x24,
+        0x0c,0xc7,0x44,0x24,0x08,0xff,0xff,0xff,0xff,0x51,0x53,0x2b,0xe0,0x56,0x57,0xa1,
+        0x70,0x14,0x01,0x10,0x33,0xc5,0x50,0x89,0x65,0xf0,0x8b,0x43,0x04,0x89,0x45,0x04,
+        0xff,0x75,0xf4,0x64,0xa1,0x00,0x00,0x00,0x00,0x89,0x45,0xf4,0x8d,0x45,0xf4,0x64,
+        0xa3,0x00,0x00,0x00,0x00,0xf2,0xc3
+    ])
+
+    PAT = """\
+518B4C240C895C240C8D5C240C508D442408F7D923C18D60F88B43F08904248B 21 B4FE 006E :0000 __EH_prolog3_GS_align ^0041 ___security_cookie ........33C5508941FC8B4DF0895DF08B4304894504FF75F464A1000000008945F48D45F464A300000000F2C3
+518B4C240C895C240C8D5C240C508D442408F7D923C18D60F88B43F08904248B 1F E4CF 0063 :0000 __EH_prolog3_align ^003F ___security_cookie ........33C5508B4304894504FF75F464A1000000008945F48D45F464A300000000F2C3
+518B4C240C895C240C8D5C240C508D442408F7D923C18D60F88B43F08904248B 22 E4CE 006F :0000 __EH_prolog3_catch_GS_align ^0042 ___security_cookie ........33C5508941FC8B4DF08965F08B4304894504FF75F464A1000000008945F48D45F464A300000000F2C3
+518B4C240C895C240C8D5C240C508D442408F7D923C18D60F88B43F08904248B 20 6562 0067 :0000 __EH_prolog3_catch_align ^0040 ___security_cookie ........33C5508965F08B4304894504FF75F464A1000000008945F48D45F464A300000000F2C3
+---
+    """
+
+    # parse signature file content into a list of signatures.
+    sigs = flirt.parse_pat(PAT)
+
+    # compile signatures into a matching engine instance.
+    # separate from above so that you can load multiple files.
+    matcher = flirt.compile(sigs)
+
+    # match the signatures against the given buffer, starting at offset 0.
+    # results in a list of rule instances with a field `name` tuple like:
+    #
+    #     ("__EH_prolog3_catch_align", "public", 0)
+    for m in matcher.match(BUF):
+        assert m.names[0][0] == "__EH_prolog3_catch_align"


### PR DESCRIPTION
This adds a recipe for python-flirt 0.9.10 (import module name used is `flirt`).