### PR TITLE
Add pyroaring package

### DIFF
--- a/packages/pyiceberg/meta.yaml
+++ b/packages/pyiceberg/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - mmh3
     - pydantic
     - pyparsing
+    - pyroaring
     - requests
     - rich
     - sortedcontainers

--- a/packages/pyroaring/meta.yaml
+++ b/packages/pyroaring/meta.yaml
@@ -1,0 +1,20 @@
+package:
+  name: pyroaring
+  version: 1.0.3
+  top-level:
+    - pyroaring
+
+source:
+  url: https://files.pythonhosted.org/packages/source/p/pyroaring/pyroaring-1.0.3.tar.gz
+  sha256: cd7392d1c010c9e41c11c62cd0610c8852e7e9698b1f7f6c2fcdefe50e7ef6da
+
+about:
+  home: https://github.com/Ezibenroc/PyRoaringBitMap
+  PyPI: https://pypi.org/project/pyroaring
+  summary:
+    Library for handling efficiently sorted integer sets.
+  license: MIT
+
+extra:
+  recipe-maintainers:
+    - nightlark

--- a/packages/pyroaring/test_pyroaring.py
+++ b/packages/pyroaring/test_pyroaring.py
@@ -1,0 +1,19 @@
+from pytest_pyodide import run_in_pyodide
+
+
+@run_in_pyodide(packages=["pyroaring"])
+def test_pyroaring(selenium):
+    from pyroaring import BitMap
+
+    bm1 = BitMap()
+    bm1.add(3)
+    bm1.add(18)
+    assert 3 in bm1
+    assert 4 not in bm1
+
+    bm2 = BitMap([3, 27, 42])
+    assert bm1 == BitMap([3, 18])
+    assert bm2 == BitMap([3, 27, 42])
+    assert bm1 & bm2 == BitMap([3])
+    assert bm1 | bm2 == BitMap([3, 18, 27, 42])
+


### PR DESCRIPTION
Adds the pyroaring 1.0.3 package, a new package that apparently has been added as a required dependency of pyiceberg in their 0.10.0 release (not sure why CI tests bumping the version of pyiceberg didn't catch it as a missing dependency).