### PR TITLE
Add segno package recipe and runtime tests

### DIFF
--- a/packages/segno/meta.yaml
+++ b/packages/segno/meta.yaml
@@ -1,0 +1,19 @@
+package:
+  name: segno
+  version: 1.6.6
+  top-level:
+    - segno
+source:
+  url: https://files.pythonhosted.org/packages/py3/s/segno/segno-1.6.6-py3-none-any.whl
+  sha256: 28c7d081ed0cf935e0411293a465efd4d500704072cdb039778a2ab8736190c7
+about:
+  home: https://github.com/heuer/segno/
+  PyPI: https://pypi.org/project/segno
+  summary: QR Code and Micro QR Code generator for Python
+  license: BSD-3-Clause
+test:
+  imports:
+    - segno
+extra:
+  recipe-maintainers:
+    - anxkhn

--- a/packages/segno/test_segno.py
+++ b/packages/segno/test_segno.py
@@ -1,0 +1,37 @@
+from pytest_pyodide import run_in_pyodide
+
+
+@run_in_pyodide(packages=["segno"])
+def test_segno_make_and_serialize(selenium_standalone):
+    import io
+
+    import segno
+
+    qr = segno.make("https://pyodide.org", micro=False, error="m")
+    assert qr.is_micro is False
+    assert qr.error in {"M", "Q", "H"}
+
+    svg = io.BytesIO()
+    png = io.BytesIO()
+    txt = io.StringIO()
+
+    qr.save(svg, kind="svg")
+    qr.save(png, kind="png", scale=2)
+    qr.save(txt, kind="txt", border=1)
+
+    assert b"<svg" in svg.getvalue()
+    assert png.getvalue().startswith(b"\x89PNG\r\n\x1a\n")
+    assert len(txt.getvalue().splitlines()) > 0
+
+
+@run_in_pyodide(packages=["segno"])
+def test_segno_sequence_and_micro(selenium_standalone):
+    import segno
+
+    micro = segno.make("RAIN")
+    assert micro.is_micro is True
+    assert micro.designator.startswith("M")
+
+    sequence = segno.make_sequence("Day after day, alone on the hill", symbol_count=2)
+    assert len(sequence) == 2
+    assert all(item.is_micro is False for item in sequence)


### PR DESCRIPTION
## Summary

- add a new `segno` recipe (`1.6.6`) as a pure Python wheel
- set package metadata (`home`, `PyPI`, `summary`, `license`, maintainer)
- add import smoke test in recipe metadata
- add package runtime tests in `packages/segno/test_segno.py`

## Why

`segno` is a useful QR Code and Micro QR Code generator that fits Pyodide packaging well:

- pure Python distribution
- no native extension dependency chain
- useful for browser-only workflows and demos

## Testing

Built recipe locally:

- `pyodide build-recipes segno --install --log-dir build-logs`

Prepared runtime:

- `./tools/copy_pyodide_runtime.sh ./dist`

Ran package tests:

- `pytest -v --dist-dir=./dist --runner=selenium --rt chrome packages/segno/test_segno.py`

Result:

- `2 passed`

Closes #556