### PR TITLE
Add jsonschema-rs package

### DIFF
--- a/packages/jsonschema-rs/meta.yaml
+++ b/packages/jsonschema-rs/meta.yaml
@@ -19,6 +19,9 @@ build:
 requirements:
   executable:
     - rustup
+test:
+  imports:
+    - jsonschema_rs
 about:
   home: https://github.com/Stranger6667/jsonschema
   PyPI: https://pypi.org/project/jsonschema-rs/0.45.0

--- a/packages/jsonschema-rs/meta.yaml
+++ b/packages/jsonschema-rs/meta.yaml
@@ -1,0 +1,29 @@
+package:
+  name: jsonschema-rs
+  version: 0.45.0
+  tag:
+    - rust
+  top-level:
+    - jsonschema_rs
+source:
+  url: https://files.pythonhosted.org/packages/d2/7b/40ed0aa40ff2f3bc9bfccf20ea29d9a99199a8eefda26ae9d65601c144fa/jsonschema_rs-0.45.0.tar.gz
+  sha256: 897deffee817fe0f493710221e19bc4d9fedabdba121d9f8e0aa824460d2498d
+  patches:
+    # Needed for https://github.com/Stranger6667/jsonschema/issues/1093
+    - patches/0001-remove-WASM-incompatible-http-options.patch
+build:
+  script: |
+    # jsonschema-rs overrides the default target set by pyodide-build so we have
+    # to set it explicitly here
+    rustup target add wasm32-unknown-emscripten
+requirements:
+  executable:
+    - rustup
+about:
+  home: https://github.com/Stranger6667/jsonschema
+  PyPI: https://pypi.org/project/jsonschema-rs/0.45.0
+  summary: "A high-performance JSON Schema validator for Python"
+  license: MIT
+extra:
+  recipe-maintainers:
+    - evroon

--- a/packages/jsonschema-rs/patches/0001-remove-WASM-incompatible-http-options.patch
+++ b/packages/jsonschema-rs/patches/0001-remove-WASM-incompatible-http-options.patch
@@ -1,0 +1,33 @@
+diff --git a/crates/jsonschema-py/src/lib.rs b/crates/jsonschema-py/src/lib.rs
+index 9c94628..2def1c7 100644
+--- a/crates/jsonschema-py/src/lib.rs
++++ b/crates/jsonschema-py/src/lib.rs
+@@ -956,28 +956,6 @@ fn make_options(
+         });
+         options = options.with_email_options(email_opts);
+     }
+-    if let Some(http_options) = http_options {
+-        let opts = http_options.extract::<HttpOptions>().map_err(|_| {
+-            exceptions::PyTypeError::new_err("http_options must be an instance of HttpOptions")
+-        })?;
+-        let mut http_opts = jsonschema::HttpOptions::new();
+-        if let Some(timeout) = opts.timeout {
+-            http_opts = http_opts.timeout(std::time::Duration::from_secs_f64(timeout));
+-        }
+-        if let Some(connect_timeout) = opts.connect_timeout {
+-            http_opts =
+-                http_opts.connect_timeout(std::time::Duration::from_secs_f64(connect_timeout));
+-        }
+-        if !opts.tls_verify {
+-            http_opts = http_opts.danger_accept_invalid_certs(true);
+-        }
+-        if let Some(ref ca_cert) = opts.ca_cert {
+-            http_opts = http_opts.add_root_certificate(ca_cert);
+-        }
+-        options = options.with_http_options(&http_opts).map_err(|e| {
+-            exceptions::PyRuntimeError::new_err(format!("Failed to configure HTTP options: {e}"))
+-        })?;
+-    }
+     if let Some(keywords) = keywords {
+         for (name, callback) in keywords.iter() {
+             let name_str = name.to_string();


### PR DESCRIPTION
Adds the [jsonschema-rs](https://github.com/Stranger6667/jsonschema/tree/master/crates/jsonschema-py) package

I am aware there is already a jsonschema package in pyodide but it doesn't have proper typing (and is less performant than jsonschema-rs).

See discussion regarding how to build this: https://github.com/pyodide/pyodide/discussions/6178