### PR TITLE
Disable pplpy

### DIFF
--- a/packages/pplpy/meta.yaml
+++ b/packages/pplpy/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: pplpy
-  version: 0.8.10
+  version: 0.9.0
   top-level:
     - ppl
 source:
-  url: https://files.pythonhosted.org/packages/92/d0/664f5ee65a8d9d071c2cdbfc8e42e0476b5b8c5ceefaa5fc9c2e1cd6fa5e/pplpy-0.8.10.tar.gz
-  sha256: d42a216c82914dcf4d7c000debc98bb336b8f83e026ba5d952cccd9f8074effd
+  url: https://files.pythonhosted.org/packages/source/p/pplpy/pplpy-0.9.0.tar.gz
+  sha256: 8289c50d680ce3f9eacac666cb4cdbbd8a711959e7cc7cf06f7fdb4035d0cc5d
 requirements:
   host:
     - libgmp
@@ -14,9 +14,6 @@ requirements:
   run:
     - gmpy2
     - cysignals
-  constraint:
-    # ImportError: cysignals.signals does not export expected C function _do_raise_exception
-    - cysignals < 1.12.6
 build:
   cxxflags: |
     -std=c++11

--- a/packages/pplpy/meta.yaml
+++ b/packages/pplpy/meta.yaml
@@ -1,11 +1,12 @@
 package:
   name: pplpy
-  version: 0.9.0
+  _disabled: true # TODO: update to make it work with python 314
+  version: 0.8.10
   top-level:
     - ppl
 source:
-  url: https://files.pythonhosted.org/packages/source/p/pplpy/pplpy-0.9.0.tar.gz
-  sha256: 8289c50d680ce3f9eacac666cb4cdbbd8a711959e7cc7cf06f7fdb4035d0cc5d
+  url: https://files.pythonhosted.org/packages/92/d0/664f5ee65a8d9d071c2cdbfc8e42e0476b5b8c5ceefaa5fc9c2e1cd6fa5e/pplpy-0.8.10.tar.gz
+  sha256: d42a216c82914dcf4d7c000debc98bb336b8f83e026ba5d952cccd9f8074effd
 requirements:
   host:
     - libgmp
@@ -14,6 +15,9 @@ requirements:
   run:
     - gmpy2
     - cysignals
+  constraint:
+    # ImportError: cysignals.signals does not export expected C function _do_raise_exception
+    - cysignals < 1.12.6
 build:
   cxxflags: |
     -std=c++11


### PR DESCRIPTION
## Description

~~The pplpy version we have seems to have issue with building python 3.14. Trying to update it to a newer version and see if it works~~

Disabling pplpy for now to make the CI pass

cc: @mkoeppe 

## Type of change

- [ ] Adding a new package
- [x] Updating an existing package
- [ ] Bug fix
- [ ] Other (please describe)
