### PR TITLE
Disable pycdfpp and primecountpy / bump FastAPI

### DIFF
--- a/packages/annotated-doc/meta.yaml
+++ b/packages/annotated-doc/meta.yaml
@@ -1,0 +1,17 @@
+package:
+  name: annotated-doc
+  version: 0.0.4
+  top-level:
+    - annotated_doc
+source:
+  url: https://files.pythonhosted.org/packages/py3/a/annotated_doc/annotated_doc-0.0.4-py3-none-any.whl
+  sha256: 571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320
+about:
+  home: https://github.com/fastapi/annotated-doc
+  PyPI: https://pypi.org/project/annotated-doc
+  summary: Document parameters, class attributes, return types, and variables
+    inline, with Annotated.
+  license: MIT
+extra:
+  recipe-maintainers:
+    - ryanking13

--- a/packages/fastapi/meta.yaml
+++ b/packages/fastapi/meta.yaml
@@ -13,6 +13,7 @@ requirements:
     - pydantic
     - starlette
     - anyio
+    - annotated-doc
 about:
   home: https://github.com/fastapi/fastapi/
   PyPI: https://pypi.org/project/fastapi

--- a/packages/fastapi/meta.yaml
+++ b/packages/fastapi/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: fastapi
-  version: 0.116.1
+  version: 0.136.1
   top-level:
     - fastapi
 source:
-  url: https://files.pythonhosted.org/packages/py3/f/fastapi/fastapi-0.116.1-py3-none-any.whl
-  sha256: c46ac7c312df840f0c9e220f7964bada936781bc4e2e6eb71f1c4d7553786565
+  url: https://files.pythonhosted.org/packages/py3/f/fastapi/fastapi-0.136.1-py3-none-any.whl
+  sha256: a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f
 requirements:
   run:
     - httpx
@@ -16,9 +16,8 @@ requirements:
 about:
   home: https://github.com/fastapi/fastapi/
   PyPI: https://pypi.org/project/fastapi
-  summary:
-    FastAPI framework, high performance, easy to learn, fast to code, ready
-    for production
+  summary: FastAPI framework, high performance, easy to learn, fast to code,
+    ready for production
   license: MIT
 extra:
   recipe-maintainers:

--- a/packages/primecountpy/meta.yaml
+++ b/packages/primecountpy/meta.yaml
@@ -1,12 +1,12 @@
 package:
   name: primecountpy
-  version: 0.1.1
+  version: 0.2.1
   top-level:
     - primecountpy
 source:
   # Cannot use tar.gz from PyPI becuase of https://github.com/dimpase/primecountpy/issues/20
-  url: https://github.com/dimpase/primecountpy/releases/download/v0.1.1/primecountpy-0.1.1.tar.gz
-  sha256: bed77c4d519092ae4489a3a8dfc2ab68e18aeec6c88dea5bb5fac6cffc0f5b20
+  url: https://files.pythonhosted.org/packages/source/p/primecountpy/primecountpy-0.2.1.tar.gz
+  sha256: 888706ab65cc089fb983de4639360dddc728baa4d9877a7ad8b116f645650b39
 about:
   home: https://github.com/dimpase/primecountpy
   PyPI: https://pypi.org/project/primecountpy
@@ -18,9 +18,6 @@ requirements:
     - libprimesieve
   run:
     - cysignals
-  constraint:
-    # ImportError: cysignals.signals does not export expected C function _do_raise_exception
-    - cysignals < 1.12.6
 build:
   cxxflags: |
     -std=c++17

--- a/packages/primecountpy/meta.yaml
+++ b/packages/primecountpy/meta.yaml
@@ -1,12 +1,13 @@
 package:
   name: primecountpy
-  version: 0.2.1
+  version: 0.1.1
+  _disabled: true  # cysignals issue
   top-level:
     - primecountpy
 source:
   # Cannot use tar.gz from PyPI becuase of https://github.com/dimpase/primecountpy/issues/20
-  url: https://files.pythonhosted.org/packages/source/p/primecountpy/primecountpy-0.2.1.tar.gz
-  sha256: 888706ab65cc089fb983de4639360dddc728baa4d9877a7ad8b116f645650b39
+  url: https://github.com/dimpase/primecountpy/releases/download/v0.1.1/primecountpy-0.1.1.tar.gz
+  sha256: bed77c4d519092ae4489a3a8dfc2ab68e18aeec6c88dea5bb5fac6cffc0f5b20
 about:
   home: https://github.com/dimpase/primecountpy
   PyPI: https://pypi.org/project/primecountpy
@@ -18,6 +19,9 @@ requirements:
     - libprimesieve
   run:
     - cysignals
+  constraint:
+    # ImportError: cysignals.signals does not export expected C function _do_raise_exception
+    - cysignals < 1.12.6
 build:
   cxxflags: |
     -std=c++17

--- a/packages/pycdfpp/meta.yaml
+++ b/packages/pycdfpp/meta.yaml
@@ -1,6 +1,7 @@
 package:
   name: pycdfpp
   version: 0.9.0
+  _disabled: true  # Remove when upstream pycdfpp release wasm wheels on PyPI
   top-level:
     - pycdfpp
 source:


### PR DESCRIPTION
## Description

Disables `pycdfpp` which have build issue with xsimd-cmake
