### PR TITLE
Update robotraconteur package to v1.2.8

### DIFF
--- a/packages/RobotRaconteur/meta.yaml
+++ b/packages/RobotRaconteur/meta.yaml
@@ -1,12 +1,12 @@
 package:
   name: RobotRaconteur
-  version: 1.2.7
+  version: 1.2.8
 
 # Please contact @johnwason before disabling!
 
 source:
-  url: https://github.com/robotraconteur/robotraconteur/releases/download/v1.2.7/RobotRaconteur-1.2.7-Source.tar.gz
-  sha256: 7d29e084f92691f58d809e26fb035465fb5df4e0c13f13c0e46fcf7eba030605
+  url: https://github.com/robotraconteur/robotraconteur/releases/download/v1.2.8/RobotRaconteur-1.2.8-Source.tar.gz
+  sha256: f77bbaa1f31cd1ee96db62926bba468e92edf35be8fd483139444f6a2dc956bc
 
 requirements:
   run:


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does. -->

## Type of change

- [ ] Adding a new package
- [x] Updating an existing package
- [ ] Bug fix
- [ ] Other (please describe)

---

> [!NOTE]
> **Considering adding a new package?**
>
> With the acceptance of [PEP 783](https://peps.python.org/pep-0783/), package maintainers can now
> build and publish Pyodide-compatible wheels (`pyemscripten` platform) directly to PyPI from their
> own repositories. This is the preferred approach going forward.
>
> Instead of adding a recipe here, we encourage you to:
> 1. Contact the package maintainers and ask them to build Emscripten/Pyodide wheels in their CI
> 2. Refer them to the [Pyodide documentation on building packages](https://pyodide-build.readthedocs.io/en/latest/)
>    and [cibuildwheel's Pyodide support](https://cibuildwheel.pypa.io/en/stable/options/#platform)
>
> We still accept new recipes, but only when it is not possible to build the package upstream.
