### PR TITLE
Add `pyproject.toml` build modernisation for `nlopt`

### DIFF
--- a/packages/nlopt/extras/pyproject.toml
+++ b/packages/nlopt/extras/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "nlopt"
+# Keep in sync with setup.py
+version = "2.9.1"
+license = "LGPL-2.1-or-later"
+dependencies = ["numpy>=1.14"]
+
+[build-system]
+requires = ["setuptools", "numpy"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = ["nlopt"]
+zip-safe = false

--- a/packages/nlopt/extras/setup.py
+++ b/packages/nlopt/extras/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import os
-import re
 from pathlib import Path
 from subprocess import check_call
 
@@ -8,16 +7,11 @@ from numpy import get_include
 from setuptools import Extension, setup
 from setuptools.command.build_py import build_py
 
+# Keep in sync with the `version` declared in pyproject.toml
+VERSION = "2.9.1"
+
 
 def create_pkg_directory():
-    with open("CMakeLists.txt") as f:
-        content = f.read()
-        version = []
-        for s in ("MAJOR", "MINOR", "BUGFIX"):
-            m = re.search(f"NLOPT_{s}_VERSION *['\"](.+)['\"]", content)
-            version.append(m.group(1))
-        version = ".".join(version)
-
     pkg_folder = Path("nlopt")
     pkg_folder.mkdir(exist_ok=True)
     with (pkg_folder / "__init__.py").open("w") as f:
@@ -25,12 +19,10 @@ def create_pkg_directory():
             f"""
 from .nlopt import *
 
-__version__ = '{version}'
+__version__ = '{VERSION}'
     """.strip()
             + "\n"
         )
-
-    return version
 
 
 def configure_with_cmake():
@@ -62,7 +54,7 @@ def configure_with_cmake():
     check_call(cmd, env=os.environ)
 
 
-version = create_pkg_directory()
+create_pkg_directory()
 
 
 class build_py_after_build_ext(build_py):
@@ -73,10 +65,6 @@ class build_py_after_build_ext(build_py):
 
 
 setup(
-    name="nlopt",
-    version=version,
-    packages=["nlopt"],
-    install_requires=["numpy >=1.14"],
     ext_modules=[
         Extension(
             "nlopt._nlopt",
@@ -155,6 +143,5 @@ setup(
             swig_opts=["-c++", "-interface", "_nlopt", "-outdir", "./nlopt"],
         )
     ],
-    zip_safe=False,
     cmdclass={"build_py": build_py_after_build_ext},
 )

--- a/packages/nlopt/meta.yaml
+++ b/packages/nlopt/meta.yaml
@@ -11,6 +11,8 @@ source:
   extras:
     - - extras/setup.py
       - ./setup.py
+    - - extras/pyproject.toml
+      - ./pyproject.toml
 
 requirements:
   host:
@@ -24,7 +26,7 @@ build:
   cxxflags: -std=c++11
 about:
   home: https://github.com/stevengj/nlopt
-  license: LGPL-2.1+
+  license: LGPL-2.1-or-later
 extra:
   recipe-maintainers:
     - mgreminger


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does. -->

Brings the nlopt modernisation from #591. The problem is that without a `pyproject.toml` file, setuptools will use the legacy build backend, and it doesn't properly detect build dependencies because it doesn't fully conform to PEP 517. This PR swaps all dynamic metadata into declarative metadata. I've also fixed the license to use the SPDX identifier.

## Type of change

- [ ] Adding a new package
- [x] Updating an existing package
- [ ] Bug fix
- [ ] Other (please describe)

---

> [!NOTE]
> **Considering adding a new package?**
>
> With the acceptance of [PEP 783](https://peps.python.org/pep-0783/), package maintainers can now
> build and publish Pyodide-compatible wheels (`pyemscripten` platform) directly to PyPI from their
> own repositories. This is the preferred approach going forward.
>
> Instead of adding a recipe here, we encourage you to:
> 1. Contact the package maintainers and ask them to build Emscripten/Pyodide wheels in their CI
> 2. Refer them to the [Pyodide documentation on building packages](https://pyodide-build.readthedocs.io/en/latest/)
>    and [cibuildwheel's Pyodide support](https://cibuildwheel.pypa.io/en/stable/options/#platform)
>
> We still accept new recipes, but only when it is not possible to build the package upstream.
