### PR TITLE
Download CLAPACK from Internet Archive for libf2c

### DIFF
--- a/packages/libf2c/meta.yaml
+++ b/packages/libf2c/meta.yaml
@@ -12,7 +12,7 @@ package:
     - static_library
 source:
   sha256: 6dc4c382164beec8aaed8fd2acc36ad24232c406eda6db462bd4c41d5e455fac
-  url: http://www.netlib.org/clapack/clapack.tgz
+  url: https://web.archive.org/web/20260509221335/https://www.netlib.org/clapack/clapack.tgz
   extract_dir: CLAPACK-3.2.1
   patches:
     - patches/0001-fix-arith.h.patch


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does. -->

We often come across errors in our CI, of the form

```python
RuntimeError: Failed to download
http://www.netlib.org/clapack/clapack.tgz after 3 trials
```

This happens a lot with GitHub Actions runners. Let's try using the Internet Archive for such links; hopefully it will be more reliable. I confirmed that the SHA-256 checksum is correct and matches the current one.

## Type of change

- [ ] Adding a new package
- [ ] Updating an existing package
- [ ] Bug fix
- [x] Other (please describe)

---

> [!NOTE]
> **Considering adding a new package?**
>
> With the acceptance of [PEP 783](https://peps.python.org/pep-0783/), package maintainers can now
> build and publish Pyodide-compatible wheels (`pyemscripten` platform) directly to PyPI from their
> own repositories. This is the preferred approach going forward.
>
> Instead of adding a recipe here, we encourage you to:
> 1. Contact the package maintainers and ask them to build Emscripten/Pyodide wheels in their CI
> 2. Refer them to the [Pyodide documentation on building packages](https://pyodide-build.readthedocs.io/en/latest/)
>    and [cibuildwheel's Pyodide support](https://cibuildwheel.pypa.io/en/stable/options/#platform)
>
> We still accept new recipes, but only when it is not possible to build the package upstream.
