### PR TITLE
doc: use archived mirror URL for libppl 1.2 source

### DIFF
--- a/packages/libppl/meta.yaml
+++ b/packages/libppl/meta.yaml
@@ -5,7 +5,7 @@ package:
     - library
     - static_library
 source:
-  url: https://mirrors.mit.edu/sage/spkg/upstream/ppl/ppl-1.2.tar.bz2
+  url: https://web.archive.org/web/20260607172720/https://mirrors.mit.edu/sage/spkg/upstream/ppl/ppl-1.2.tar.bz2
   sha256: 2d470b0c262904f190a19eac57fb5c2387b1bfc3510de25a08f3c958df62fdf1
   patches:
     - patches/clang5-support.patch


### PR DESCRIPTION
## Description

This updates `packages/libppl/meta.yaml` to fetch the existing `ppl-1.2.tar.bz2` source from a stable Internet Archive snapshot instead of the MIT mirrors host.

## Type of change

- [x] Bug fix
- [ ] Adding a new package
- [ ] Updating an existing package
- [ ] Other

Closes #594.

## Validation

- Verified SHA-256 of the archived tarball matches the existing value in `packages/libppl/meta.yaml`:
  - `2d470b0c262904f190a19eac57fb5c2387b1bfc3510de25a08f3c958df62fdf1`
- `npm run check` could not be run: repository has no `package.json` in this environment.
