### PR TITLE
CI Add a script to check pyemscripten wheels in PyPI

### DIFF
--- a/.github/workflows/check-pyemscripten-wheels.yml
+++ b/.github/workflows/check-pyemscripten-wheels.yml
@@ -1,0 +1,46 @@
+name: Check pyemscripten wheels on PyPI
+
+on:
+  # Run once a week, on Monday at 5am UTC
+  schedule:
+    - cron: "0 5 * * 1"
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-pyemscripten-wheels:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc # v6.4.3
+        with:
+          python-version: "3.13"
+
+      - name: Check PyPI for pyemscripten wheels and update tracker issue
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          uv run tools/check_pyemscripten_wheels.py \
+            --update-issue \
+            --output-json pyemscripten-wheel-status.json \
+            --output-markdown pyemscripten-wheel-status.md
+
+      - name: Upload status report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: pyemscripten-wheel-status
+          path: |
+            pyemscripten-wheel-status.json
+            pyemscripten-wheel-status.md
+          retention-days: 30

--- a/tools/check_pyemscripten_wheels.py
+++ b/tools/check_pyemscripten_wheels.py
@@ -1,0 +1,547 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "ruamel.yaml",
+# ]
+# ///
+"""Check which source-built recipes already ship a PEP 783 ``pyemscripten`` wheel on PyPI.
+
+This script does three things:
+
+1. Scans every package recipe in the ``packages/`` directory and selects the ones
+   that are *built from source* (i.e. ``source/url`` is an sdist/tarball, not a
+   pre-built ``.whl``, and the recipe is a real Python ``package`` rather than a
+   C ``static_library`` / ``shared_library`` / ``cpython_module``).
+
+2. For each of those recipes it queries the PyPI Simple JSON API and checks
+   whether the project publishes at least one wheel whose platform tag matches
+   the PEP 783 ``pyemscripten`` series, i.e. the regular expression
+   ``pyemscripten_[0-9]+_[0-9]+_wasm32`` (see https://peps.python.org/pep-0783/).
+
+3. Optionally (``--update-issue``) it creates or updates a GitHub issue that
+   tracks which packages now have an upstream ``pyemscripten`` wheel on PyPI, so
+   that those recipes can eventually be removed from this repository.
+
+Run it directly with ``uv`` (no manual dependency installation needed)::
+
+    uv run tools/check_pyemscripten_wheels.py
+
+Dependencies are declared in the PEP 723 inline-script metadata block above.
+"""
+import argparse
+import concurrent.futures
+import dataclasses
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from ruamel.yaml import YAML
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+RECIPE_DIR = BASE_DIR / "packages"
+
+# PEP 783 platform tag series. Package indexes "SHOULD accept any wheel whose
+# platform tag matches the regular expression pyemscripten_[0-9]+_[0-9]+_wasm32".
+PEP783_PLATFORM_RE = re.compile(r"pyemscripten_[0-9]+_[0-9]+_wasm32")
+# A wheel filename embeds platform tags in its last "-" separated component(s),
+# e.g. ``numpy-2.4.3-cp314-cp314-pyemscripten_2026_0_wasm32.whl``.
+PEP783_WHEEL_RE = re.compile(r"pyemscripten_[0-9]+_[0-9]+_wasm32(?=[.\-])")
+
+PYPI_SIMPLE_URL = "https://pypi.org/simple/{name}/"
+PYPI_SIMPLE_ACCEPT = "application/vnd.pypi.simple.v1+json"
+
+GITHUB_API = "https://api.github.com"
+
+DEFAULT_ISSUE_TITLE = "Tracking: packages with upstream pyemscripten wheels on PyPI"
+DEFAULT_ISSUE_LABEL = "pyemscripten-wheel-tracker"
+# Hidden marker so we can reliably find the issue we previously created.
+ISSUE_MARKER = "<!-- pyemscripten-wheel-tracker:do-not-remove -->"
+
+USER_AGENT = "pyodide-recipes-pyemscripten-checker/1.0"
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    with path.open() as f:
+        data = YAML(typ="safe").load(f)
+    if not isinstance(data, dict):
+        raise ValueError(f"{path}: meta.yaml did not parse to a mapping")
+    return data
+
+
+@dataclasses.dataclass
+class Recipe:
+    recipe_name: str
+    package_name: str
+    version: str
+    source_url: str | None
+    build_type: str
+
+    @property
+    def is_source_built(self) -> bool:
+        """True if this recipe is built from source (not a pre-built wheel)."""
+        if self.source_url is None:
+            # No URL means an in-tree (source/path) recipe such as numpy-tests;
+            # not something published on PyPI.
+            return False
+        if self.source_url.endswith(".whl"):
+            return False
+        # Only real Python packages live on PyPI as pyemscripten wheels.
+        return self.build_type == "package"
+
+
+def load_recipe(meta_path: Path) -> Recipe | None:
+    """Load a single recipe; returns ``None`` if it cannot be parsed."""
+    try:
+        meta = _load_yaml(meta_path)
+    except Exception as exc:  # noqa: BLE001 - we want to skip broken recipes
+        print(f"WARNING: failed to parse {meta_path}: {exc}", file=sys.stderr)
+        return None
+
+    package = meta.get("package") or {}
+    source = meta.get("source") or {}
+    build = meta.get("build") or {}
+
+    return Recipe(
+        recipe_name=meta_path.parent.name,
+        package_name=package.get("name") or meta_path.parent.name,
+        version=str(package.get("version", "")),
+        source_url=source.get("url"),
+        build_type=str(build.get("type", "package")),
+    )
+
+
+def iter_recipes(packages_dir: Path) -> list[Recipe]:
+    recipes: list[Recipe] = []
+    for meta_path in sorted(packages_dir.glob("*/meta.yaml")):
+        recipe = load_recipe(meta_path)
+        if recipe is not None:
+            recipes.append(recipe)
+    return recipes
+
+
+@dataclasses.dataclass
+class PyPIResult:
+    found: bool
+    matching_wheels: list[str]
+    platform_tags: list[str]
+    wheel_versions: list[str]
+    error: str | None = None
+
+
+def _http_get_json(
+    url: str, accept: str, timeout: float, retries: int = 3
+) -> tuple[int, Any]:
+    last_exc: Exception | None = None
+    for _attempt in range(retries):
+        request = urllib.request.Request(  # noqa: S310 - https URL, fixed scheme
+            url, headers={"Accept": accept, "User-Agent": USER_AGENT}
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
+                payload = response.read().decode("utf-8")
+            return response.status, json.loads(payload)
+        except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                return 404, None
+            last_exc = exc
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+            last_exc = exc
+    raise RuntimeError(f"GET {url} failed after {retries} attempts: {last_exc}")
+
+
+def _version_from_wheel(filename: str) -> str:
+    """Extract the version component from a wheel filename.
+
+    Wheel filename: ``{name}-{version}(-{build})?-{python}-{abi}-{platform}.whl``.
+    """
+    parts = filename[: -len(".whl")].split("-")
+    if len(parts) >= 2:
+        return parts[1]
+    return ""
+
+
+def check_pypi_for_pyemscripten(name: str, timeout: float) -> PyPIResult:
+    """Query the PyPI Simple JSON API for ``name`` and look for pyemscripten wheels."""
+    url = PYPI_SIMPLE_URL.format(name=name)
+    try:
+        status, data = _http_get_json(url, PYPI_SIMPLE_ACCEPT, timeout)
+    except RuntimeError as exc:
+        return PyPIResult(False, [], [], [], error=str(exc))
+
+    if status == 404 or data is None:
+        return PyPIResult(False, [], [], [], error="not found on PyPI")
+
+    matching_wheels: list[str] = []
+    platform_tags: set[str] = set()
+    wheel_versions: set[str] = set()
+
+    for file_entry in data.get("files", []):
+        filename = file_entry.get("filename", "")
+        if not filename.endswith(".whl"):
+            continue
+        tag_match = PEP783_WHEEL_RE.search(filename)
+        if tag_match:
+            matching_wheels.append(filename)
+            platform_tags.add(tag_match.group(0))
+            wheel_versions.add(_version_from_wheel(filename))
+
+    return PyPIResult(
+        found=bool(matching_wheels),
+        matching_wheels=sorted(matching_wheels),
+        platform_tags=sorted(platform_tags),
+        wheel_versions=sorted(wheel_versions),
+    )
+
+
+@dataclasses.dataclass
+class PackageStatus:
+    recipe: str
+    pypi_name: str
+    recipe_version: str
+    has_pyemscripten_wheel: bool
+    matching_wheels: list[str]
+    platform_tags: list[str]
+    wheel_versions: list[str]
+    error: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+def build_report(
+    recipes: list[Recipe], max_workers: int, timeout: float
+) -> dict[str, Any]:
+    source_recipes = [r for r in recipes if r.is_source_built]
+
+    statuses: list[PackageStatus] = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+        future_to_recipe = {
+            executor.submit(check_pypi_for_pyemscripten, r.package_name, timeout): r
+            for r in source_recipes
+        }
+        for future in concurrent.futures.as_completed(future_to_recipe):
+            recipe = future_to_recipe[future]
+            result = future.result()
+            statuses.append(
+                PackageStatus(
+                    recipe=recipe.recipe_name,
+                    pypi_name=recipe.package_name,
+                    recipe_version=recipe.version,
+                    has_pyemscripten_wheel=result.found,
+                    matching_wheels=result.matching_wheels,
+                    platform_tags=result.platform_tags,
+                    wheel_versions=result.wheel_versions,
+                    error=result.error,
+                )
+            )
+
+    statuses.sort(key=lambda s: s.recipe.lower())
+    available = [s for s in statuses if s.has_pyemscripten_wheel]
+
+    return {
+        "generated_at": datetime.now(UTC).isoformat(),
+        "pep783_platform_regex": PEP783_PLATFORM_RE.pattern,
+        "total_recipes": len(recipes),
+        "total_source_recipes": len(source_recipes),
+        "available_count": len(available),
+        "packages": [s.to_dict() for s in statuses],
+    }
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    generated = report["generated_at"]
+    total_source = report["total_source_recipes"]
+    available = report["available_count"]
+    packages: list[dict[str, Any]] = report["packages"]
+
+    available_pkgs = [p for p in packages if p["has_pyemscripten_wheel"]]
+    errored_pkgs = [
+        p for p in packages if not p["has_pyemscripten_wheel"] and p["error"] and p["error"] != "not found on PyPI"
+    ]
+
+    lines: list[str] = []
+    lines.append(ISSUE_MARKER)
+    lines.append("")
+    lines.append(
+        "This issue is automatically maintained by "
+        "[`tools/check_pyemscripten_wheels.py`](../blob/main/tools/check_pyemscripten_wheels.py)."
+    )
+    lines.append("")
+    lines.append(
+        "It tracks **source-built** recipes in this repository whose upstream "
+        "project now publishes a [PEP 783](https://peps.python.org/pep-0783/) "
+        "`pyemscripten` wheel on PyPI. Once a package ships such a wheel upstream, "
+        "the recipe here can usually be removed."
+    )
+    lines.append("")
+    lines.append(f"- **Last updated:** {generated}")
+    lines.append(f"- **Source-built recipes scanned:** {total_source}")
+    lines.append(f"- **Recipes with an upstream `pyemscripten` wheel:** {available}")
+    lines.append(f"- **Platform tag pattern:** `{report['pep783_platform_regex']}`")
+    lines.append("")
+
+    lines.append("## Candidates for removal (pyemscripten wheel available on PyPI)")
+    lines.append("")
+    if available_pkgs:
+        lines.append(
+            "| Recipe | PyPI | Recipe version | Wheel version(s) | Platform tag(s) |"
+        )
+        lines.append("| --- | --- | --- | --- | --- |")
+        for pkg in available_pkgs:
+            pypi_link = f"[{pkg['pypi_name']}](https://pypi.org/project/{pkg['pypi_name']}/)"
+            wheel_versions = ", ".join(pkg["wheel_versions"]) or "—"
+            platform_tags = "<br>".join(f"`{t}`" for t in pkg["platform_tags"]) or "—"
+            lines.append(
+                f"| `{pkg['recipe']}` | {pypi_link} | {pkg['recipe_version']} "
+                f"| {wheel_versions} | {platform_tags} |"
+            )
+    else:
+        lines.append("_None yet._")
+    lines.append("")
+
+    lines.append(
+        f"<details><summary>Recipes still without an upstream pyemscripten wheel "
+        f"({total_source - available})</summary>"
+    )
+    lines.append("")
+    not_available = [p for p in packages if not p["has_pyemscripten_wheel"]]
+    if not_available:
+        lines.append("| Recipe | PyPI | Recipe version | Note |")
+        lines.append("| --- | --- | --- | --- |")
+        for pkg in not_available:
+            note = pkg["error"] or ""
+            lines.append(
+                f"| `{pkg['recipe']}` | `{pkg['pypi_name']}` "
+                f"| {pkg['recipe_version']} | {note} |"
+            )
+    else:
+        lines.append("_All scanned recipes have an upstream wheel._")
+    lines.append("")
+    lines.append("</details>")
+    lines.append("")
+
+    if errored_pkgs:
+        lines.append(
+            f"> [!WARNING]\n> {len(errored_pkgs)} package(s) could not be checked due "
+            "to PyPI errors; their status may be inaccurate this run."
+        )
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def _github_request(
+    method: str,
+    path: str,
+    token: str,
+    payload: dict[str, Any] | None = None,
+    timeout: float = 30.0,
+) -> tuple[int, Any]:
+    url = path if path.startswith("http") else f"{GITHUB_API}{path}"
+    data = json.dumps(payload).encode("utf-8") if payload is not None else None
+    request = urllib.request.Request(url, data=data, method=method)  # noqa: S310
+    request.add_header("Authorization", f"Bearer {token}")
+    request.add_header("Accept", "application/vnd.github+json")
+    request.add_header("X-GitHub-Api-Version", "2022-11-28")
+    request.add_header("User-Agent", USER_AGENT)
+    if data is not None:
+        request.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
+            body = response.read().decode("utf-8")
+        return response.status, json.loads(body) if body else None
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        try:
+            parsed = json.loads(body)
+        except json.JSONDecodeError:
+            parsed = body
+        return exc.code, parsed
+
+
+def _ensure_label(repo: str, token: str, label: str) -> None:
+    status, _ = _github_request(
+        "POST",
+        f"/repos/{repo}/labels",
+        token,
+        {
+            "name": label,
+            "color": "0e8a16",
+            "description": "Recipes whose upstream now ships a PEP 783 pyemscripten wheel",
+        },
+    )
+    # 201 = created, 422 = already exists. Anything else is surprising but non-fatal.
+    if status not in (201, 422):
+        print(f"WARNING: could not ensure label {label!r} (HTTP {status})", file=sys.stderr)
+
+
+def _find_tracker_issue(repo: str, token: str, label: str) -> int | None:
+    # Listing by our own label is immediate and reliable (no search index delay).
+    status, issues = _github_request(
+        "GET", f"/repos/{repo}/issues?state=all&labels={label}&per_page=100", token
+    )
+    if status != 200 or not isinstance(issues, list):
+        return None
+    for issue in issues:
+        # Skip pull requests, which the issues endpoint also returns.
+        if "pull_request" in issue:
+            continue
+        if ISSUE_MARKER in (issue.get("body") or ""):
+            return int(issue["number"])
+    # Fall back to the first non-PR issue carrying the label.
+    for issue in issues:
+        if "pull_request" not in issue:
+            return int(issue["number"])
+    return None
+
+
+def update_github_issue(
+    repo: str, token: str, title: str, label: str, body: str
+) -> None:
+    _ensure_label(repo, token, label)
+    issue_number = _find_tracker_issue(repo, token, label)
+
+    if issue_number is None:
+        status, data = _github_request(
+            "POST",
+            f"/repos/{repo}/issues",
+            token,
+            {"title": title, "body": body, "labels": [label]},
+        )
+        if status == 201:
+            print(f"Created tracker issue #{data['number']}: {data['html_url']}")
+        else:
+            raise RuntimeError(f"Failed to create issue (HTTP {status}): {data}")
+    else:
+        status, data = _github_request(
+            "PATCH",
+            f"/repos/{repo}/issues/{issue_number}",
+            token,
+            {"title": title, "body": body},
+        )
+        if status == 200:
+            print(f"Updated tracker issue #{issue_number}: {data['html_url']}")
+        else:
+            raise RuntimeError(
+                f"Failed to update issue #{issue_number} (HTTP {status}): {data}"
+            )
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "-d",
+        "--packages-dir",
+        type=Path,
+        default=RECIPE_DIR,
+        help="Directory containing the package recipes (default: ./packages).",
+    )
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        default=None,
+        help="Write the full machine-readable status report to this JSON file.",
+    )
+    parser.add_argument(
+        "--output-markdown",
+        type=Path,
+        default=None,
+        help="Write the rendered Markdown report to this file.",
+    )
+    parser.add_argument(
+        "--max-workers",
+        type=int,
+        default=16,
+        help="Number of concurrent PyPI requests (default: 16).",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=30.0,
+        help="Per-request timeout in seconds (default: 30).",
+    )
+    parser.add_argument(
+        "--update-issue",
+        action="store_true",
+        help="Create or update the GitHub tracker issue (needs GITHUB_TOKEN).",
+    )
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("GITHUB_REPOSITORY"),
+        help="GitHub repository in 'owner/name' form (default: $GITHUB_REPOSITORY).",
+    )
+    parser.add_argument(
+        "--issue-title",
+        default=DEFAULT_ISSUE_TITLE,
+        help="Title for the tracker issue.",
+    )
+    parser.add_argument(
+        "--issue-label",
+        default=DEFAULT_ISSUE_LABEL,
+        help="Label used to find/create the tracker issue.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    packages_dir = args.packages_dir.resolve()
+    if not packages_dir.is_dir():
+        print(f"ERROR: packages directory not found: {packages_dir}", file=sys.stderr)
+        return 1
+
+    recipes = iter_recipes(packages_dir)
+    source_count = sum(1 for r in recipes if r.is_source_built)
+    print(
+        f"Scanned {len(recipes)} recipes; {source_count} are built from source.",
+        file=sys.stderr,
+    )
+
+    report = build_report(recipes, max_workers=args.max_workers, timeout=args.timeout)
+    markdown = render_markdown(report)
+
+    if args.output_json:
+        args.output_json.write_text(json.dumps(report, indent=2) + "\n")
+        print(f"Wrote JSON report to {args.output_json}", file=sys.stderr)
+    if args.output_markdown:
+        args.output_markdown.write_text(markdown + "\n")
+        print(f"Wrote Markdown report to {args.output_markdown}", file=sys.stderr)
+
+    print(
+        f"{report['available_count']} / {report['total_source_recipes']} "
+        "source-built recipes now have an upstream pyemscripten wheel on PyPI.",
+        file=sys.stderr,
+    )
+
+    if args.update_issue:
+        token = os.environ.get("GITHUB_TOKEN")
+        if not token:
+            print("ERROR: --update-issue requires GITHUB_TOKEN", file=sys.stderr)
+            return 1
+        if not args.repo:
+            print(
+                "ERROR: --update-issue requires --repo or $GITHUB_REPOSITORY",
+                file=sys.stderr,
+            )
+            return 1
+        update_github_issue(
+            args.repo, token, args.issue_title, args.issue_label, markdown
+        )
+    else:
+        # When not updating the issue, emit the Markdown to stdout so it can be
+        # inspected or piped elsewhere.
+        print(markdown)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Purely written in AI. TBH, I didn't read the code in detail.

Adds a script that check which packages in this repository has a pyemscripten wheels in PyPI. It creates and updates the GH issue regularly so we can track the progress. Currently it shows:

---

Scanned 346 recipes; 175 are built from source.
3 / 175 source-built recipes now have an upstream pyemscripten wheel on PyPI.
<!-- pyemscripten-wheel-tracker:do-not-remove -->

This issue is automatically maintained by [`tools/check_pyemscripten_wheels.py`](../blob/main/tools/check_pyemscripten_wheels.py).

It tracks **source-built** recipes in this repository whose upstream project now publishes a [PEP 783](https://peps.python.org/pep-0783/) `pyemscripten` wheel on PyPI. Once a package ships such a wheel upstream, the recipe here can usually be removed.

- **Last updated:** 2026-06-08T06:09:04.887375+00:00
- **Source-built recipes scanned:** 175
- **Recipes with an upstream `pyemscripten` wheel:** 3
- **Platform tag pattern:** `pyemscripten_[0-9]+_[0-9]+_wasm32`

## Candidates for removal (pyemscripten wheel available on PyPI)

| Recipe | PyPI | Recipe version | Wheel version(s) | Platform tag(s) |
| --- | --- | --- | --- | --- |
| `pycdfpp` | [pycdfpp](https://pypi.org/project/pycdfpp/) | 0.9.0 | 0.9.3 | `pyemscripten_2025_0_wasm32` |
| `pydantic_core` | [pydantic_core](https://pypi.org/project/pydantic_core/) | 2.41.5 | 2.47.0 | `pyemscripten_2026_0_wasm32` |
| `RobotRaconteur` | [RobotRaconteur](https://pypi.org/project/RobotRaconteur/) | 1.2.8 | 1.2.8 | `pyemscripten_2026_0_wasm32` |

<details><summary>Recipes still without an upstream pyemscripten wheel (172)</summary>

| Recipe | PyPI | Recipe version | Note |
| --- | --- | --- | --- |
| `aiohttp` | `aiohttp` | 3.13.5 |  |
| `apsw` | `apsw` | 3.51.3.0 |  |
| `argon2-cffi` | `argon2-cffi` | 23.1.0 |  |
| `argon2-cffi-bindings` | `argon2-cffi-bindings` | 25.1.0 |  |
| `astropy` | `astropy` | 7.2.0 |  |
| `atomicwrites` | `atomicwrites` | 1.4.1 |  |
| `audioop-lts` | `audioop-lts` | 0.2.2 |  |
| `awkward-cpp` | `awkward-cpp` | 52 |  |
| `b2d` | `b2d` | 0.7.4 |  |
| `bcrypt` | `bcrypt` | 5.0.0 |  |
| `bilby.cython` | `bilby.cython` | 0.5.4 |  |
| `biopython` | `biopython` | 1.87 |  |
| `bitarray` | `bitarray` | 3.8.1 |  |
| `blosc2` | `blosc2` | 4.1.2 |  |
| `bokeh` | `bokeh` | 3.9.0 |  |
| `boost-histogram` | `boost-histogram` | 1.7.1 |  |
| `Bottleneck` | `Bottleneck` | 1.6.0 |  |
| `brotli` | `brotli` | 1.2.0 |  |
| `Cartopy` | `Cartopy` | 0.25.0 |  |
| `casadi` | `casadi` | 3.7.2 |  |
| `cbor-diag` | `cbor-diag` | 1.1.2 |  |
| `cffi` | `cffi` | 2.0.0 |  |
| `cffi_example` | `cffi_example` | 0.1 | not found on PyPI |
| `cftime` | `cftime` | 1.6.5 |  |
| `clarabel` | `clarabel` | 0.11.1 |  |
| `clingo` | `clingo` | 5.8.0 |  |
| `cobs` | `cobs` | 1.2.2 |  |
| `contourpy` | `contourpy` | 1.3.3 |  |
| `coolprop` | `coolprop` | 7.2.0 |  |
| `coverage` | `coverage` | 7.13.5 |  |
| `cramjam` | `cramjam` | 2.11.0 |  |
| `crc32c` | `crc32c` | 2.8 |  |
| `crcmod` | `crcmod` | 1.7 |  |
| `cryptography` | `cryptography` | 47.0.0 |  |
| `cvxpy-base` | `cvxpy-base` | 1.8.2 |  |
| `cysignals` | `cysignals` | 1.12.3 |  |
| `cytoolz` | `cytoolz` | 1.1.0 |  |
| `ewah_bool_utils` | `ewah_bool_utils` | 1.3.0 |  |
| `fastcan` | `fastcan` | 0.5.0 |  |
| `fastparquet` | `fastparquet` | 2024.11.0 |  |
| `fiona` | `fiona` | 1.9.5 |  |
| `freesasa` | `freesasa` | 2.2.1 |  |
| `frozenlist` | `frozenlist` | 1.8.0 |  |
| `future` | `future` | 1.0.0 |  |
| `galpy` | `galpy` | 1.11.2 |  |
| `gensim` | `gensim` | 4.3.3 |  |
| `gmpy2` | `gmpy2` | 2.3.0 |  |
| `google-crc32c` | `google-crc32c` | 1.8.0 |  |
| `gsw` | `gsw` | 3.6.21 |  |
| `h3` | `h3` | 4.4.2 |  |
| `h5py` | `h5py` | 3.13.0 |  |
| `healpy` | `healpy` | 1.19.0 |  |
| `highspy` | `highspy` | 1.13.1 |  |
| `httpx` | `httpx` | 0.28.1 |  |
| `igraph` | `igraph` | 1.0.0 |  |
| `iminuit` | `iminuit` | 2.30.1 |  |
| `jiter` | `jiter` | 0.13.0 |  |
| `joblib` | `joblib` | 1.5.3 |  |
| `kiwisolver` | `kiwisolver` | 1.5.0 |  |
| `lakers-python` | `lakers-python` | 0.6.2 |  |
| `lazy-object-proxy` | `lazy-object-proxy` | 1.12.0 |  |
| `libcst` | `libcst` | 1.8.6 |  |
| `librt` | `librt` | 0.8.1 |  |
| `lightgbm` | `lightgbm` | 4.6.0 |  |
| `logbook` | `logbook` | 1.9.2 |  |
| `lxml` | `lxml` | 6.0.2 |  |
| `lz4` | `lz4` | 4.4.5 |  |
| `MarkupSafe` | `MarkupSafe` | 3.0.3 |  |
| `matplotlib` | `matplotlib` | 3.10.8 |  |
| `memory-allocator` | `memory-allocator` | 0.2.0 |  |
| `ml_dtypes` | `ml_dtypes` | 0.5.4 |  |
| `mmh3` | `mmh3` | 5.2.1 |  |
| `msgpack` | `msgpack` | 1.1.2 |  |
| `msgspec` | `msgspec` | 0.20.0 |  |
| `msprime` | `msprime` | 1.4.1 |  |
| `multidict` | `multidict` | 6.7.1 |  |
| `mypy` | `mypy` | 1.19.1 |  |
| `ndindex` | `ndindex` | 1.10.1 |  |
| `netcdf4` | `netcdf4` | 1.7.4 |  |
| `nh3` | `nh3` | 0.3.4 |  |
| `nlopt` | `nlopt` | 2.9.1 |  |
| `numcodecs` | `numcodecs` | 0.15.1 |  |
| `numpy` | `numpy` | 2.4.3 |  |
| `opencv-python` | `opencv-python` | 4.11.0.86 |  |
| `orjson` | `orjson` | 3.11.8 |  |
| `packaging` | `packaging` | 26.1 |  |
| `pandas` | `pandas` | 3.0.2 |  |
| `patsy` | `patsy` | 1.0.2 |  |
| `pcodec` | `pcodec` | 1.0.1 |  |
| `peewee` | `peewee` | 4.0.4 |  |
| `phispy` | `phispy` | 5.0.6 |  |
| `pi-heif` | `pi-heif` | 1.3.0 |  |
| `Pillow` | `Pillow` | 12.2.0 |  |
| `pillow-heif` | `pillow-heif` | 1.3.0 |  |
| `pplpy` | `pplpy` | 0.8.10 |  |
| `primecountpy` | `primecountpy` | 0.1.1 |  |
| `protobuf` | `protobuf` | 7.34.1 |  |
| `pyclipper` | `pyclipper` | 1.4.0 |  |
| `pycryptodome` | `pycryptodome` | 3.23.0 |  |
| `pydantic` | `pydantic` | 2.12.5 |  |
| `pyerfa` | `pyerfa` | 2.0.1.5 |  |
| `pygame-ce` | `pygame-ce` | 2.5.7 |  |
| `pyheif` | `pyheif` | 0.8.0 |  |
| `pyiceberg` | `pyiceberg` | 0.11.1 |  |
| `pyinstrument` | `pyinstrument` | 5.1.2 |  |
| `pymongo` | `pymongo` | 4.16.0 |  |
| `PyMuPDF` | `PyMuPDF` | 1.27.2.2 |  |
| `pynacl` | `pynacl` | 1.6.2 |  |
| `pyproj` | `pyproj` | 3.7.2 |  |
| `pyroaring` | `pyroaring` | 1.0.4 |  |
| `pyrodigal` | `pyrodigal` | 3.7.1 |  |
| `pyrsistent` | `pyrsistent` | 0.20.0 |  |
| `pysam` | `pysam` | 0.23.0 |  |
| `pytaglib` | `pytaglib` | 3.2.0 |  |
| `pytest-benchmark` | `pytest-benchmark` | 4.0.0 |  |
| `python-calamine` | `python-calamine` | 0.6.2 |  |
| `python-flint` | `python-flint` | 0.8.0 |  |
| `python-flirt` | `python-flirt` | 0.9.10 |  |
| `python-magic` | `python-magic` | 0.4.27 |  |
| `python-sat` | `python-sat` | 1.8.dev26 |  |
| `python-solvespace` | `python-solvespace` | 3.0.8 |  |
| `pywavelets` | `pywavelets` | 1.9.0 |  |
| `pyxirr` | `pyxirr` | 0.10.8 |  |
| `pyyaml` | `pyyaml` | 6.0.3 |  |
| `rasterio` | `rasterio` | 1.5.0 |  |
| `rateslib` | `rateslib` | 2.7.1 |  |
| `rebound` | `rebound` | 4.4.7 |  |
| `reboundx` | `reboundx` | 4.4.1 |  |
| `regex` | `regex` | 2026.3.32 |  |
| `retrying` | `retrying` | 1.4.2 |  |
| `river` | `river` | 0.23.0 |  |
| `rpds-py` | `rpds-py` | 0.30.0 |  |
| `rustworkx` | `rustworkx` | 0.17.1 |  |
| `safetensors` | `safetensors` | 0.7.0 |  |
| `scikit-image` | `scikit-image` | 0.25.2 |  |
| `scikit-learn` | `scikit-learn` | 1.8.0 |  |
| `scipy` | `scipy` | 1.17.1 |  |
| `screed` | `screed` | 1.1.3 |  |
| `sentencepiece` | `sentencepiece` | 0.2.1 |  |
| `shapely` | `shapely` | 2.1.2 |  |
| `simplejson` | `simplejson` | 3.20.2 |  |
| `sisl` | `sisl` | 0.16.4 |  |
| `soundfile` | `soundfile` | 0.12.1 |  |
| `sourmash` | `sourmash` | 4.8.14 |  |
| `soxr` | `soxr` | 0.5.0.post1 |  |
| `sparseqr` | `sparseqr` | 1.2 |  |
| `sqlalchemy` | `sqlalchemy` | 2.0.48 |  |
| `statsmodels` | `statsmodels` | 0.14.6 |  |
| `swiglpk` | `swiglpk` | 5.0.13 |  |
| `termcolor` | `termcolor` | 3.3.0 |  |
| `texture2ddecoder` | `texture2ddecoder` | 1.0.6 |  |
| `tiktoken` | `tiktoken` | 0.12.0 |  |
| `traits` | `traits` | 7.1.0 |  |
| `tree-sitter` | `tree-sitter` | 0.23.2 |  |
| `tree-sitter-go` | `tree-sitter-go` | 0.23.3 |  |
| `tree-sitter-java` | `tree-sitter-java` | 0.23.4 |  |
| `tree-sitter-python` | `tree-sitter-python` | 0.23.4 |  |
| `tskit` | `tskit` | 1.0.2 |  |
| `ujson` | `ujson` | 5.12.0 |  |
| `uncertainties` | `uncertainties` | 3.2.3 |  |
| `urllib3` | `urllib3` | 2.6.3 |  |
| `wordcloud` | `wordcloud` | 1.9.6 |  |
| `wrapt` | `wrapt` | 2.1.2 |  |
| `xgboost` | `xgboost` | 2.1.4 |  |
| `xxhash` | `xxhash` | 3.6.0 |  |
| `xyzservices` | `xyzservices` | 2026.3.0 |  |
| `yarl` | `yarl` | 1.23.0 |  |
| `yt` | `yt` | 4.4.0 |  |
| `zarr` | `zarr` | 3.2.1 |  |
| `zengl` | `zengl` | 2.7.2 |  |
| `zfpy` | `zfpy` | 1.0.1 |  |
| `zstandard` | `zstandard` | 0.25.0 |  |

</details>