### PR TITLE
Update libppl source mirror

### DIFF
--- a/packages/libppl/meta.yaml
+++ b/packages/libppl/meta.yaml
@@ -5,7 +5,7 @@ package:
     - library
     - static_library
 source:
-  url: https://mirrors.mit.edu/sage/spkg/upstream/ppl/ppl-1.2.tar.bz2
+  url: https://www.mirrorservice.org/sites/www.sagemath.org/spkg/upstream/ppl/ppl-1.2.tar.bz2
   sha256: 2d470b0c262904f190a19eac57fb5c2387b1bfc3510de25a08f3c958df62fdf1
   patches:
     - patches/clang5-support.patch


### PR DESCRIPTION
## Summary
- Replace the libppl source URL with an alternate Sage mirror.
- Keep the existing SHA256, verified against the replacement download.

Closes #594

## Validation
- git diff --check
- Downloaded replacement tarball and verified SHA256 matches the existing recipe checksum