### PR TITLE
Use Pyodide 314.0.0 stable xbuildenv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,4 +81,3 @@ asyncio_mode = "strict"
 
 [tool.pyodide.build]
 rust_toolchain = "1.93.0"
-default_cross_build_env_url = "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20260324_314_alpha/xbuildenv.tar.bz2"


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does. -->

I have already done this in #586 and #554. We've pinned to 314.0.0a1 for some time now; let's update to use the stable release now that it's out. Running the full build here.

## Type of change

- [ ] Adding a new package
- [ ] Updating an existing package
- [ ] Bug fix
- [x] Other (please describe): updates the build pipeline to use 314.0.0 stable instead of 314.0.0a1.

---

> [!NOTE]
> **Considering adding a new package?**
>
> With the acceptance of [PEP 783](https://peps.python.org/pep-0783/), package maintainers can now
> build and publish Pyodide-compatible wheels (`pyemscripten` platform) directly to PyPI from their
> own repositories. This is the preferred approach going forward.
>
> Instead of adding a recipe here, we encourage you to:
> 1. Contact the package maintainers and ask them to build Emscripten/Pyodide wheels in their CI
> 2. Refer them to the [Pyodide documentation on building packages](https://pyodide-build.readthedocs.io/en/latest/)
>    and [cibuildwheel's Pyodide support](https://cibuildwheel.pypa.io/en/stable/options/#platform)
>
> We still accept new recipes, but only when it is not possible to build the package upstream.
