### PR TITLE
Update libngspice to 46 and inspice to 1.7.0.5

### DIFF
--- a/packages/inspice/meta.yaml
+++ b/packages/inspice/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: inspice
-  version: 1.7.0.1
+  version: 1.7.0.5
   top-level:
     - InSpice
 source:
-  url: https://files.pythonhosted.org/packages/py3/i/inspice/inspice-1.7.0.1-py3-none-any.whl
-  sha256: fb2d94f96e22830ffdf8e5d104b2c904f7a7382d9b4b1f23bb871d02a2ed4bef
+  url: https://files.pythonhosted.org/packages/py3/i/inspice/inspice-1.7.0.5-py3-none-any.whl
+  sha256: 7c4c0ce6b9c9610380285859bc93858a4ef73c7c079522683832d5be4bfdc8f8
 requirements:
   run:
     - numpy

--- a/packages/libngspice/meta.yaml
+++ b/packages/libngspice/meta.yaml
@@ -1,13 +1,12 @@
 package:
   name: libngspice
-  version: "44.2"
-  _disabled: true  #  error: 'is_compound' cannot be specialized: Users are not allowed to specialize this standard library entity [-Winvalid-specialization]
+  version: "46"
   tag:
     - library
     - shared_library
 source:
-  url: https://github.com/danchitnis/ngspice-sf-mirror/archive/refs/tags/ngspice-44.2.zip
-  sha256: 3ae94703938247a22148f60a1307d52719d42a9134b5aef6252594000f513902
+  url: https://github.com/danchitnis/ngspice-sf-mirror/archive/refs/tags/ngspice-46.zip
+  sha256: 7a2ee6e9b1cf3a6fc875d74b4822c05d2d5933af4ec90a8fbafd08b11638a406
   patches:
     - patches/0001-keep-alive-API-functions.patch
     - patches/0002-fix-hicum2-extern-c.patch

--- a/packages/libngspice/meta.yaml
+++ b/packages/libngspice/meta.yaml
@@ -7,10 +7,12 @@ package:
 source:
   url: https://github.com/danchitnis/ngspice-sf-mirror/archive/refs/tags/ngspice-46.zip
   sha256: 7a2ee6e9b1cf3a6fc875d74b4822c05d2d5933af4ec90a8fbafd08b11638a406
+  extract_dir: ngspice-sf-mirror-ngspice-46
   patches:
     - patches/0001-keep-alive-API-functions.patch
     - patches/0002-fix-hicum2-extern-c.patch
     - patches/0003-fix-verilog-install-hook.patch
+    - patches/0004-fix-emscripten-memory-size.patch
 
 build:
   type: shared_library

--- a/packages/libngspice/patches/0004-fix-emscripten-memory-size.patch
+++ b/packages/libngspice/patches/0004-fix-emscripten-memory-size.patch
@@ -1,0 +1,64 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Pepijn de Vos <pepijndevos@gmail.com>
+Date: Tue, 30 Jun 2026 00:00:00 +0000
+Subject: [PATCH] Report WASM heap as memory size under Emscripten
+
+ngspice 46 added an available-memory check in OUTpD_memory() (frontend/
+outitf.c) that aborts the run when the estimated output size exceeds the
+reported free memory. Under Emscripten there is no /proc/meminfo, so
+getMemorySize()/getAvailableMemorySize() opened it, failed, and returned
+0. The check then always tripped, leading to a bogus multi-GB allocation
+and "ngspice.dll cannot recover" abort even for tiny circuits.
+
+Report the Emscripten heap (max / max-current) instead so the memory
+check sees realistic values and the simulation runs normally.
+--- a/src/frontend/get_avail_mem_size.c
++++ b/src/frontend/get_avail_mem_size.c
+@@ -7,6 +7,10 @@
+ #include "ngspice/ngspice.h"
+ #include "resource.h"
+ 
++#if defined(__EMSCRIPTEN__)
++#include <emscripten/heap.h>
++#endif
++
+ #if defined(_WIN32)
+ #include <windows.h>
+ 
+@@ -31,7 +35,10 @@
+  */
+ unsigned long long getAvailableMemorySize(void)
+ {
+-#if defined(HAVE__PROC_MEMINFO)
++#if defined(__EMSCRIPTEN__)
++    /* No /proc/meminfo under WASM; estimate free space from the heap. */
++    return (unsigned long long) (emscripten_get_heap_max() - emscripten_get_heap_size());
++#elif defined(HAVE__PROC_MEMINFO)
+     /* Cygwin , Linux--------------------------------- */
+     /* Search for string "MemFree" */
+     FILE *fp;
+--- a/src/frontend/get_phys_mem_size.c
++++ b/src/frontend/get_phys_mem_size.c
+@@ -9,6 +9,10 @@
+ #include "ngspice/ngspice.h"
+ #include "resource.h"
+ 
++#if defined(__EMSCRIPTEN__)
++#include <emscripten/heap.h>
++#endif
++
+ #if defined(_WIN32)
+ #include <windows.h>
+ 
+@@ -31,7 +35,10 @@
+  */
+ unsigned long long getMemorySize(void)
+ {
+-#if defined(HAVE__PROC_MEMINFO)
++#if defined(__EMSCRIPTEN__)
++    /* No /proc/meminfo under WASM; report the max the heap can grow to. */
++    return (unsigned long long) emscripten_get_heap_max();
++#elif defined(HAVE__PROC_MEMINFO)
+     /* Cygwin , Linux--------------------------------- */
+     FILE *fp;
+     char buffer[2048];


### PR DESCRIPTION
## Description

ngspice 46 removes the cppduals std::is_compound specialization that newer clang/libc++ rejected with -Winvalid-specialization, which was the error that had disabled the libngspice recipe. Bumping to 46 fixes the build natively, so re-enable the recipe (drop _disabled).

All three existing patches still apply cleanly to ngspice 46.

Bump inspice to 1.7.0.5 to match; runtime dependencies are unchanged and the NgSpiceShared API used by the tests is intact.

## Type of change

- [ ] Adding a new package
- [x] Updating an existing package
- [x] Bug fix
- [ ] Other (please describe)

---

If there is a reasonable way to ship libngspice on pypi I might do that at some point.

aiui I'll have to wait for the next release for this to be picked up? (and for marimo to pick up that release...)