### PR TITLE
Update Fiona to drop deprecated oldest-supported-numpy usage

### DIFF
--- a/packages/fiona/meta.yaml
+++ b/packages/fiona/meta.yaml
@@ -1,10 +1,9 @@
 package:
   name: fiona
-  version: 1.9.5
-  pinned: true
+  version: 1.10.1
 source:
-  url: https://files.pythonhosted.org/packages/83/a0/6b870864ceebcd046d2e952b0d18932812ff7a48d3b05670af3f702d9c01/fiona-1.9.5.tar.gz
-  sha256: 99e2604332caa7692855c2ae6ed91e1fffdf9b59449aa8032dd18e070e59a2f7
+  url: https://files.pythonhosted.org/packages/source/f/fiona/fiona-1.10.1.tar.gz
+  sha256: b00ae357669460c6491caba29c2022ff0acfcbde86a95361ea8ff5cd14a86b68
 test:
   imports:
     - fiona


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does. -->

## Type of change

- [ ] Adding a new package
- [x] Updating an existing package
- [ ] Bug fix
- [ ] Other (please describe)

This PR is split off from #591, and updates Fiona to a newer version, unpinning it, as the current version uses the long-deprecated `oldest-supported-numpy` dependency at build-time, which will become a hard error after https://github.com/pyodide/pyodide-build/pull/21 is merged and released.

---

> [!NOTE]
> **Considering adding a new package?**
>
> With the acceptance of [PEP 783](https://peps.python.org/pep-0783/), package maintainers can now
> build and publish Pyodide-compatible wheels (`pyemscripten` platform) directly to PyPI from their
> own repositories. This is the preferred approach going forward.
>
> Instead of adding a recipe here, we encourage you to:
> 1. Contact the package maintainers and ask them to build Emscripten/Pyodide wheels in their CI
> 2. Refer them to the [Pyodide documentation on building packages](https://pyodide-build.readthedocs.io/en/latest/)
>    and [cibuildwheel's Pyodide support](https://cibuildwheel.pypa.io/en/stable/options/#platform)
>
> We still accept new recipes, but only when it is not possible to build the package upstream.
