### PR TITLE
Add a recipe for the BLIS framework and associated patches

### DIFF
--- a/packages/libblis/meta.yaml
+++ b/packages/libblis/meta.yaml
@@ -1,0 +1,42 @@
+package:
+  name: libblis
+  version: "2.0"
+  tag:
+    - library
+    - shared_library
+source:
+  url: https://github.com/flame/blis/archive/refs/tags/2.1.tar.gz
+  sha256: 901752ec596cd63421ea45a6a06a9f34491cf5ae01cea412ece05f97a2690a96
+  patches:
+    # Derived from https://github.com/agriyakhetarpal/blis/pull/1
+    - patches/0001-Compile-BLIS-to-WebAssembly.patch
+    # See https://github.com/flame/blis/issues/916. This patch is a backport of
+    # https://github.com/flame/blis/pull/926 add CBLAS wrappers for Givens rotation
+    # functions in the BLIS f2c compat layer. The patch is needed for SciPy's test
+    # suite to pass.
+    - patches/0002-CBLAS-interface-for-crotg-zrotg-zdrot-and-csrot.patch
+
+build:
+  type: shared_library
+  script: |
+    CC=emcc AR=emar RANLIB=emranlib \
+      ./configure \
+        --disable-threading \
+        --disable-shared \
+        --enable-cblas \
+        --prefix=${WASM_LIBRARY_DIR} \
+        wasm32
+
+    emmake make -j ${PYODIDE_JOBS:-3}
+    emmake make install
+
+    mkdir -p dist
+    emcc ${WASM_LIBRARY_DIR}/lib/libblis.a \
+        ${SIDE_MODULE_LDFLAGS} \
+        -o dist/libblis.so
+
+    cp dist/libblis.so ${WASM_LIBRARY_DIR}/lib/libblis.so
+about:
+  home: https://github.com/flame/blis
+  license: BSD-3-Clause
+  summary: BLAS-like Library Instantiation Software Framework

--- a/packages/libblis/meta.yaml
+++ b/packages/libblis/meta.yaml
@@ -33,7 +33,9 @@ build:
     mkdir -p dist
     emcc ${WASM_LIBRARY_DIR}/lib/libblis.a \
         ${SIDE_MODULE_LDFLAGS} \
-        -o ${WASM_LIBRARY_DIR}/lib/libblis.so
+        -o dist/libblis.so
+
+    cp dist/libblis.so ${WASM_LIBRARY_DIR}/lib/libblis.so
 about:
   home: https://github.com/flame/blis
   license: BSD-3-Clause

--- a/packages/libblis/meta.yaml
+++ b/packages/libblis/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: libblis
-  version: "2.0"
+  version: "2.1"
   tag:
     - library
     - shared_library

--- a/packages/libblis/meta.yaml
+++ b/packages/libblis/meta.yaml
@@ -33,9 +33,7 @@ build:
     mkdir -p dist
     emcc ${WASM_LIBRARY_DIR}/lib/libblis.a \
         ${SIDE_MODULE_LDFLAGS} \
-        -o dist/libblis.so
-
-    cp dist/libblis.so ${WASM_LIBRARY_DIR}/lib/libblis.so
+        -o ${WASM_LIBRARY_DIR}/lib/libblis.so
 about:
   home: https://github.com/flame/blis
   license: BSD-3-Clause

--- a/packages/libblis/patches/0001-Compile-BLIS-to-WebAssembly.patch
+++ b/packages/libblis/patches/0001-Compile-BLIS-to-WebAssembly.patch
@@ -1,0 +1,348 @@
+From 85aa27abe96e988adc8fdfbf61844bfd3307ccbf Mon Sep 17 00:00:00 2001
+From: Agriya Khetarpal <74401230+agriyakhetarpal@users.noreply.github.com>
+Date: Tue, 30 Jun 2026 06:06:59 +0530
+Subject: Compile BLIS to WebAssembly
+
+This is a squashed patch from https://github.com/agriyakhetarpal/blis/pull/1
+and applied on top of the v2.1 release of BLIS. See the release notes at:
+https://github.com/flame/blis/releases/tag/2.1
+
+The patch adds support for compiling BLIS to WebAssembly using Emscripten.
+The following changes have been made:
+
+* Treat Emscripten vendor as Clang
+* Generate compile rule for `obj/wasm32/config/wasm32`
+* Rename ref kernel init function after wasm32 config
+* Include `WASM32` in `INSERT_GENTCONF`
+* Declare BLIS_ARCH_WASM32
+* Compile with PIC for Pyodide shared module
+* Add family and kernel definitions headers
+
+---
+ config/wasm32/bli_cntx_init_wasm32.c    | 40 +++++++++++++
+ config/wasm32/bli_family_wasm32.h       | 38 +++++++++++++
+ config/wasm32/bli_kernel_defs_wasm32.h  | 38 +++++++++++++
+ config/wasm32/make_defs.mk              | 74 +++++++++++++++++++++++++
+ config_registry                         |  1 +
+ configure                               |  6 ++
+ frame/base/bli_arch.c                   |  7 +++
+ frame/include/bli_gentconf_macro_defs.h | 12 +++-
+ frame/include/bli_type_defs.h           |  3 +
+ 9 files changed, 218 insertions(+), 1 deletion(-)
+ create mode 100644 config/wasm32/bli_cntx_init_wasm32.c
+ create mode 100644 config/wasm32/bli_family_wasm32.h
+ create mode 100644 config/wasm32/bli_kernel_defs_wasm32.h
+ create mode 100644 config/wasm32/make_defs.mk
+
+diff --git a/config/wasm32/bli_cntx_init_wasm32.c b/config/wasm32/bli_cntx_init_wasm32.c
+new file mode 100644
+index 00000000..bc0f86b9
+--- /dev/null
++++ b/config/wasm32/bli_cntx_init_wasm32.c
+@@ -0,0 +1,40 @@
++/*
++
++   BLIS
++   An object-based framework for developing high-performance BLAS-like
++   libraries.
++
++   Copyright (C) 2014, The University of Texas at Austin
++
++   Redistribution and use in source and binary forms, with or without
++   modification, are permitted provided that the following conditions are
++   met:
++    - Redistributions of source code must retain the above copyright
++      notice, this list of conditions and the following disclaimer.
++    - Redistributions in binary form must reproduce the above copyright
++      notice, this list of conditions and the following disclaimer in the
++      documentation and/or other materials provided with the distribution.
++    - Neither the name(s) of the copyright holder(s) nor the names of its
++      contributors may be used to endorse or promote products derived
++      from this software without specific prior written permission.
++
++   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
++   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
++   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
++   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
++   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
++   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
++   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
++   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
++   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
++   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++
++*/
++
++#include "blis.h"
++
++void bli_cntx_init_wasm32( cntx_t* cntx )
++{
++	bli_cntx_init_wasm32_ref( cntx );
++}
+diff --git a/config/wasm32/bli_family_wasm32.h b/config/wasm32/bli_family_wasm32.h
+new file mode 100644
+index 00000000..74dbaf22
+--- /dev/null
++++ b/config/wasm32/bli_family_wasm32.h
+@@ -0,0 +1,38 @@
++/*
++
++   BLIS
++   An object-based framework for developing high-performance BLAS-like
++   libraries.
++
++   Copyright (C) 2014, The University of Texas at Austin
++
++   Redistribution and use in source and binary forms, with or without
++   modification, are permitted provided that the following conditions are
++   met:
++    - Redistributions of source code must retain the above copyright
++      notice, this list of conditions and the following disclaimer.
++    - Redistributions in binary form must reproduce the above copyright
++      notice, this list of conditions and the following disclaimer in the
++      documentation and/or other materials provided with the distribution.
++    - Neither the name(s) of the copyright holder(s) nor the names of its
++      contributors may be used to endorse or promote products derived
++      from this software without specific prior written permission.
++
++   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
++   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
++   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
++   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
++   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
++   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
++   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
++   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
++   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
++   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++
++*/
++
++// This file is intentionally left blank.No family-specific configuration
++// is needed for wasm32. We still need to provide this file so that the
++// build system can find it and compile it, but it does not need to
++// contain any code.
+diff --git a/config/wasm32/bli_kernel_defs_wasm32.h b/config/wasm32/bli_kernel_defs_wasm32.h
+new file mode 100644
+index 00000000..73f8d513
+--- /dev/null
++++ b/config/wasm32/bli_kernel_defs_wasm32.h
+@@ -0,0 +1,38 @@
++/*
++
++   BLIS
++   An object-based framework for developing high-performance BLAS-like
++   libraries.
++
++   Copyright (C) 2014, The University of Texas at Austin
++
++   Redistribution and use in source and binary forms, with or without
++   modification, are permitted provided that the following conditions are
++   met:
++    - Redistributions of source code must retain the above copyright
++      notice, this list of conditions and the following disclaimer.
++    - Redistributions in binary form must reproduce the above copyright
++      notice, this list of conditions and the following disclaimer in the
++      documentation and/or other statements provided with the distribution.
++    - Neither the name(s) of the copyright holder(s) nor the names of its
++      contributors may be used to endorse or promote products derived
++      from this software without specific prior written permission.
++
++   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
++   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
++   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
++   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
++   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
++   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
++   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
++   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
++   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
++   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++
++*/
++
++// This file is intentionally left blank. No kernel overrides are needed
++// because we have used generic reference kernels for wasm32. We still need
++// to provide this file so that the build system can find it and compile it,
++// but it does not need to contain any code.
+diff --git a/config/wasm32/make_defs.mk b/config/wasm32/make_defs.mk
+new file mode 100644
+index 00000000..27020ccb
+--- /dev/null
++++ b/config/wasm32/make_defs.mk
+@@ -0,0 +1,74 @@
++#
++#
++#  BLIS
++#  An object-based framework for developing high-performance BLAS-like
++#  libraries.
++#
++#  Copyright (C) 2014, The University of Texas at Austin
++#
++#  Redistribution and use in source and binary forms, with or without
++#  modification, are permitted provided that the following conditions are
++#  met:
++#   - Redistributions of source code must retain the above copyright
++#     notice, this list of conditions and the following disclaimer.
++#   - Redistributions in binary form must reproduce the above copyright
++#     notice, this list of conditions and the following disclaimer in the
++#     documentation and/or other materials provided with the distribution.
++#   - Neither the name(s) of the copyright holder(s) nor the names of its
++#     contributors may be used to endorse or promote products derived
++#     from this software without specific prior written permission.
++#
++#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
++#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
++#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
++#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
++#  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
++#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
++#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
++#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
++#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
++#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++#
++#
++
++# Declare the name of the current configuration and add it to the
++# running list of configurations included by common.mk.
++THIS_CONFIG    := wasm32
++#CONFIGS_INCL   += $(THIS_CONFIG)
++
++#
++# --- Determine the C compiler and related flags ---
++#
++
++# NOTE: configure normalises emcc to cc_vendor=clang, so CC_VENDOR=clang here.
++CPPROCFLAGS    :=
++CMISCFLAGS     :=
++CPICFLAGS      := -fPIC
++CWARNFLAGS     :=
++
++ifneq ($(DEBUG_TYPE),off)
++CDBGFLAGS      := -g
++endif
++
++ifeq ($(DEBUG_TYPE),noopt)
++COPTFLAGS      := -O0
++else
++COPTFLAGS      := -O2
++endif
++
++# Flags specific to optimized kernels.
++CKOPTFLAGS     := $(COPTFLAGS) -O3
++CKVECFLAGS     :=
++
++# Flags specific to reference kernels.
++CROPTFLAGS     := $(CKOPTFLAGS)
++ifeq ($(CC_VENDOR),clang)
++CRVECFLAGS     := $(CKVECFLAGS) -funsafe-math-optimizations -ffp-contract=fast
++else
++CRVECFLAGS     := $(CKVECFLAGS)
++endif
++
++# Store all of the variables here to new variables containing the
++# configuration name.
++$(eval $(call store-make-defs,$(THIS_CONFIG)))
+diff --git a/config_registry b/config_registry
+index 8c1f6f25..a865e51c 100644
+--- a/config_registry
++++ b/config_registry
+@@ -66,3 +66,4 @@ sifive_x280: sifive_x280
+ 
+ # Generic architectures.
+ generic:     generic
++wasm32:      wasm32/generic
+diff --git a/configure b/configure
+index 34f71e36..2ac56b49 100755
+--- a/configure
++++ b/configure
+@@ -1685,6 +1685,12 @@ get_compiler_version()
+ 		             | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.?[0-9]*' \
+ 		             | { read -r first rest ; echo "${first}"; })
+ 
++	elif [ "${cc_vendor}" = "emcc" ]; then
++		cc_vendor="clang"
++		cc_version=$(echo "${vendor_string}" \
++		             | grep -oE '[0-9]+\.[0-9]+\.?[0-9]*' \
++		             | { read -r first rest ; echo "${first}"; })
++
+ 	elif [ "${cc_vendor}" = "NVIDIA" ]; then
+ 
+ 		cc_version=$(echo "${vendor_string}" \
+diff --git a/frame/base/bli_arch.c b/frame/base/bli_arch.c
+index f7a6d693..198dad26 100644
+--- a/frame/base/bli_arch.c
++++ b/frame/base/bli_arch.c
+@@ -319,6 +319,11 @@ arch_t bli_arch_query_id_impl( void )
+ 		id = BLIS_ARCH_SIFIVE_X280;
+ 		#endif
+ 
++		// WebAssembly.
++		#ifdef BLIS_FAMILY_WASM32
++		id = BLIS_ARCH_WASM32;
++		#endif
++
+ 		// Generic microarchitecture.
+ 		#ifdef BLIS_FAMILY_GENERIC
+ 		id = BLIS_ARCH_GENERIC;
+@@ -386,6 +391,8 @@ static const char* config_name[ BLIS_NUM_ARCHS ] =
+ 
+     "sifive_x280",
+ 
++    "wasm32",
++
+     "generic"
+ };
+ 
+diff --git a/frame/include/bli_gentconf_macro_defs.h b/frame/include/bli_gentconf_macro_defs.h
+index 70414fb4..818a159c 100644
+--- a/frame/include/bli_gentconf_macro_defs.h
++++ b/frame/include/bli_gentconf_macro_defs.h
+@@ -236,6 +236,14 @@
+ #define INSERT_GENTCONF_GENERIC
+ #endif
+ 
++// -- WebAssembly architectures ------------------------------------------------
++
++#ifdef BLIS_CONFIG_WASM32
++#define INSERT_GENTCONF_WASM32 GENTCONF( WASM32, wasm32 )
++#else
++#define INSERT_GENTCONF_WASM32
++#endif
++
+ 
+ // -- configuration-specific macro --
+ 
+@@ -282,7 +290,9 @@ INSERT_GENTCONF_RV64IV \
+ \
+ INSERT_GENTCONF_SIFIVE_X280 \
+ \
+-INSERT_GENTCONF_GENERIC
++INSERT_GENTCONF_GENERIC \
++\
++INSERT_GENTCONF_WASM32
+ 
+ 
+ #endif
+diff --git a/frame/include/bli_type_defs.h b/frame/include/bli_type_defs.h
+index 8fe8e5ed..a005bd97 100644
+--- a/frame/include/bli_type_defs.h
++++ b/frame/include/bli_type_defs.h
+@@ -1009,6 +1009,9 @@ typedef enum arch_e
+ 	// SiFive
+ 	BLIS_ARCH_SIFIVE_X280,
+ 
++	// WebAssembly
++	BLIS_ARCH_WASM32,
++
+ 	// Generic architecture/configuration
+ 	BLIS_ARCH_GENERIC,
+ 
+-- 
+2.50.1 (Apple Git-155)
+

--- a/packages/libblis/patches/0002-CBLAS-interface-for-crotg-zrotg-zdrot-and-csrot.patch
+++ b/packages/libblis/patches/0002-CBLAS-interface-for-crotg-zrotg-zdrot-and-csrot.patch
@@ -1,0 +1,321 @@
+From 8ef1abca0c395dbc02dba134c088fc403fe8c782 Mon Sep 17 00:00:00 2001
+From: Edward Smyth <117460141+edwsmyth@users.noreply.github.com>
+Date: Sun, 28 Jun 2026 20:47:26 +0100
+Subject: [PATCH 2/2] CBLAS interface for crotg, zrotg, zdrot and csrot (#926)
+
+Details:
+- Add CBLAS wrappers for missing complex rot APIs, as requested in
+  https://github.com/flame/blis/issues/916.
+
+This patch has been backported to be applied to the 2.1 release of BLIS.
+
+---
+ frame/compat/cblas/src/cblas.h       | 11 ++++--
+ frame/compat/cblas/src/cblas_crotg.c | 50 ++++++++++++++++++++++++
+ frame/compat/cblas/src/cblas_csrot.c | 58 ++++++++++++++++++++++++++++
+ frame/compat/cblas/src/cblas_f77.h   |  6 ++-
+ frame/compat/cblas/src/cblas_zdrot.c | 58 ++++++++++++++++++++++++++++
+ frame/compat/cblas/src/cblas_zrotg.c | 50 ++++++++++++++++++++++++
+ 6 files changed, 228 insertions(+), 5 deletions(-)
+ create mode 100644 frame/compat/cblas/src/cblas_crotg.c
+ create mode 100644 frame/compat/cblas/src/cblas_csrot.c
+ create mode 100644 frame/compat/cblas/src/cblas_zdrot.c
+ create mode 100644 frame/compat/cblas/src/cblas_zrotg.c
+
+diff --git a/frame/compat/cblas/src/cblas.h b/frame/compat/cblas/src/cblas.h
+index 0a29c915..79f999f6 100644
+--- a/frame/compat/cblas/src/cblas.h
++++ b/frame/compat/cblas/src/cblas.h
+@@ -120,7 +120,7 @@ void BLIS_EXPORT_BLAS cblas_zaxpy(f77_int N, const void *alpha, const void *X,
+ 
+ 
+ /*
+- * Routines with S and D prefix only
++ * Routines with S D C Z CS and ZD prefixes
+  */
+ void BLIS_EXPORT_BLAS cblas_srotg(float *a, float *b, float *c, float *s);
+ void BLIS_EXPORT_BLAS cblas_srotmg(float *d1, float *d2, float *b1, const float b2, float *P);
+@@ -136,10 +136,13 @@ void BLIS_EXPORT_BLAS cblas_drot(f77_int N, double *X, f77_int incX,
+ void BLIS_EXPORT_BLAS cblas_drotm(f77_int N, double *X, f77_int incX,
+                 double *Y, f77_int incY, const double *P);
+ 
++void BLIS_EXPORT_BLAS cblas_crotg(void *a, void *b, float *c, void *s);
++void BLIS_EXPORT_BLAS cblas_csrot(f77_int N, void *X, f77_int incX,
++                void *Y, f77_int incY, const float c, const float s);
++void BLIS_EXPORT_BLAS cblas_zrotg(void *a, void *b, double *c, void *s);
++void BLIS_EXPORT_BLAS cblas_zdrot(f77_int N, void *X, f77_int incX,
++                void *Y, f77_int incY, const double c, const double s);
+ 
+-/*
+- * Routines with S D C Z CS and ZD prefixes
+- */
+ void BLIS_EXPORT_BLAS cblas_sscal(f77_int N, float alpha, float *X, f77_int incX);
+ void BLIS_EXPORT_BLAS cblas_dscal(f77_int N, double alpha, double *X, f77_int incX);
+ void BLIS_EXPORT_BLAS cblas_cscal(f77_int N, const void *alpha, void *X, f77_int incX);
+diff --git a/frame/compat/cblas/src/cblas_crotg.c b/frame/compat/cblas/src/cblas_crotg.c
+new file mode 100644
+index 00000000..00c6f02d
+--- /dev/null
++++ b/frame/compat/cblas/src/cblas_crotg.c
+@@ -0,0 +1,50 @@
++/*
++
++   BLIS
++   An object-based framework for developing high-performance BLAS-like
++   libraries.
++
++   Copyright (C) 2024 - 2026, Advanced Micro Devices, Inc. All rights reserved.
++
++   Redistribution and use in source and binary forms, with or without
++   modification, are permitted provided that the following conditions are
++   met:
++    - Redistributions of source code must retain the above copyright
++      notice, this list of conditions and the following disclaimer.
++    - Redistributions in binary form must reproduce the above copyright
++      notice, this list of conditions and the following disclaimer in the
++      documentation and/or other materials provided with the distribution.
++    - Neither the name(s) of the copyright holder(s) nor the names of its
++      contributors may be used to endorse or promote products derived
++      from this software without specific prior written permission.
++
++   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
++   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
++   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
++   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
++   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
++   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
++   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
++   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
++   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
++   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++
++*/
++
++#include "blis.h"
++#ifdef BLIS_ENABLE_CBLAS
++/*
++ * cblas_crotg.c
++ *
++ * The program is a C interface to crotg.
++ *
++ *
++ */
++#include "cblas.h"
++#include "cblas_f77.h"
++void cblas_crotg( void *a, void *b, float *c, void *s )
++{
++   F77_crotg((scomplex*)a, (scomplex*)b, c, (scomplex*)s);
++}
++#endif
+diff --git a/frame/compat/cblas/src/cblas_csrot.c b/frame/compat/cblas/src/cblas_csrot.c
+new file mode 100644
+index 00000000..1fd98c2a
+--- /dev/null
++++ b/frame/compat/cblas/src/cblas_csrot.c
+@@ -0,0 +1,58 @@
++/*
++
++   BLIS
++   An object-based framework for developing high-performance BLAS-like
++   libraries.
++
++   Copyright (C) 2024 - 2026, Advanced Micro Devices, Inc. All rights reserved.
++
++   Redistribution and use in source and binary forms, with or without
++   modification, are permitted provided that the following conditions are
++   met:
++    - Redistributions of source code must retain the above copyright
++      notice, this list of conditions and the following disclaimer.
++    - Redistributions in binary form must reproduce the above copyright
++      notice, this list of conditions and the following disclaimer in the
++      documentation and/or other materials provided with the distribution.
++    - Neither the name(s) of the copyright holder(s) nor the names of its
++      contributors may be used to endorse or promote products derived
++      from this software without specific prior written permission.
++
++   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
++   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
++   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
++   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
++   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
++   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
++   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
++   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
++   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
++   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++
++*/
++
++#include "blis.h"
++#ifdef BLIS_ENABLE_CBLAS
++/*
++ * cblas_csrot.c
++ *
++ * The program is a C interface to csrot.
++ *
++ *
++ */
++#include "cblas.h"
++#include "cblas_f77.h"
++void cblas_csrot( f77_int N, void *X, f77_int incX, void *Y,
++                f77_int incY, const float c, const float s )
++{
++#ifdef F77_INT
++   F77_INT F77_N=N, F77_incX=incX; F77_incY=incY;
++#else
++   #define F77_N N
++   #define F77_incX incX
++   #define F77_incY incY
++#endif
++   F77_csrot( &F77_N, (scomplex*)X, &F77_incX, (scomplex*)Y, &F77_incY, &c, &s );
++}
++#endif
+diff --git a/frame/compat/cblas/src/cblas_f77.h b/frame/compat/cblas/src/cblas_f77.h
+index acb354aa..e7f4fd90 100644
+--- a/frame/compat/cblas/src/cblas_f77.h
++++ b/frame/compat/cblas/src/cblas_f77.h
+@@ -14,7 +14,7 @@
+    An object-based framework for developing high-performance BLAS-like
+    libraries.
+ 
+-   Copyright (C) 2020, Advanced Micro Devices, Inc. All rights reserved.
++   Copyright (C) 2020 - 2026, Advanced Micro Devices, Inc. All rights reserved.
+ 
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+@@ -57,6 +57,10 @@
+ #define F77_drotmg     drotmg_
+ #define F77_drot       drot_
+ #define F77_drotm      drotm_
++#define F77_crotg      crotg_
++#define F77_csrot      csrot_
++#define F77_zrotg      zrotg_
++#define F77_zdrot      zdrot_
+ #define F77_sswap      sswap_
+ #define F77_scopy      scopy_
+ #define F77_saxpy      saxpy_
+diff --git a/frame/compat/cblas/src/cblas_zdrot.c b/frame/compat/cblas/src/cblas_zdrot.c
+new file mode 100644
+index 00000000..b20487ed
+--- /dev/null
++++ b/frame/compat/cblas/src/cblas_zdrot.c
+@@ -0,0 +1,58 @@
++/*
++
++   BLIS
++   An object-based framework for developing high-performance BLAS-like
++   libraries.
++
++   Copyright (C) 2024 - 2026, Advanced Micro Devices, Inc. All rights reserved.
++
++   Redistribution and use in source and binary forms, with or without
++   modification, are permitted provided that the following conditions are
++   met:
++    - Redistributions of source code must retain the above copyright
++      notice, this list of conditions and the following disclaimer.
++    - Redistributions in binary form must reproduce the above copyright
++      notice, this list of conditions and the following disclaimer in the
++      documentation and/or other materials provided with the distribution.
++    - Neither the name(s) of the copyright holder(s) nor the names of its
++      contributors may be used to endorse or promote products derived
++      from this software without specific prior written permission.
++
++   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
++   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
++   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
++   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
++   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
++   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
++   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
++   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
++   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
++   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++
++*/
++
++#include "blis.h"
++#ifdef BLIS_ENABLE_CBLAS
++/*
++ * cblas_zdrot.c
++ *
++ * The program is a C interface to zdrot.
++ *
++ *
++ */
++#include "cblas.h"
++#include "cblas_f77.h"
++void cblas_zdrot( f77_int N, void *X, f77_int incX, void *Y,
++                f77_int incY, const double c, const double s )
++{
++#ifdef F77_INT
++   F77_INT F77_N=N, F77_incX=incX; F77_incY=incY;
++#else
++   #define F77_N N
++   #define F77_incX incX
++   #define F77_incY incY
++#endif
++   F77_zdrot( &F77_N, (dcomplex*)X, &F77_incX, (dcomplex*)Y, &F77_incY, &c, &s );
++}
++#endif
+diff --git a/frame/compat/cblas/src/cblas_zrotg.c b/frame/compat/cblas/src/cblas_zrotg.c
+new file mode 100644
+index 00000000..30cfaa72
+--- /dev/null
++++ b/frame/compat/cblas/src/cblas_zrotg.c
+@@ -0,0 +1,50 @@
++/*
++
++   BLIS
++   An object-based framework for developing high-performance BLAS-like
++   libraries.
++
++   Copyright (C) 2024 - 2026, Advanced Micro Devices, Inc. All rights reserved.
++
++   Redistribution and use in source and binary forms, with or without
++   modification, are permitted provided that the following conditions are
++   met:
++    - Redistributions of source code must retain the above copyright
++      notice, this list of conditions and the following disclaimer.
++    - Redistributions in binary form must reproduce the above copyright
++      notice, this list of conditions and the following disclaimer in the
++      documentation and/or other materials provided with the distribution.
++    - Neither the name(s) of the copyright holder(s) nor the names of its
++      contributors may be used to endorse or promote products derived
++      from this software without specific prior written permission.
++
++   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
++   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
++   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
++   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
++   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
++   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
++   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
++   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
++   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
++   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++
++*/
++
++#include "blis.h"
++#ifdef BLIS_ENABLE_CBLAS
++/*
++ * cblas_zrotg.c
++ *
++ * The program is a C interface to zrotg.
++ *
++ *
++ */
++#include "cblas.h"
++#include "cblas_f77.h"
++void cblas_zrotg( void *a, void *b, double *c, void *s )
++{
++   F77_zrotg((dcomplex*)a, (dcomplex*)b, c, (dcomplex*)s);
++}
++#endif
+-- 
+2.50.1 (Apple Git-155)
+

--- a/packages/libblis/test_libblis.py
+++ b/packages/libblis/test_libblis.py
@@ -1,0 +1,129 @@
+"""
+Functional tests for libblis.
+
+We exercise one routine from each BLAS level, and plus the complex Givens
+rotation wrappers added in patch 0002.
+
+The expected values were computed with a native version of SciPy. In order
+to reproduce the reference numbers, run the snippet below
+
+```
+import numpy as np
+from scipy.linalg import blas
+
+x = np.array([1., 2., 3., 4.])
+y = np.array([5., 6., 7., 8.])
+assert blas.ddot(x, y) == 70.0
+assert blas.dnrm2(np.array([3., 4.])) == 5.0
+assert blas.dasum(np.array([-1., 2., -3.])) == 6.0
+assert list(
+    blas.daxpy(np.array([1., 2., 3.]),
+    np.array([4., 5., 6.]), a=2.0),
+) == [6., 9., 12.]
+
+A = np.arange(1, 10, dtype=float).reshape(3, 3)
+assert list(A @ np.ones(3)) == [6., 15., 24.]
+
+Am = np.array([[1., 2.], [3., 4.]])
+Bm = np.array([[5., 6.], [7., 8.]])
+assert list((Am @ Bm).ravel()) == [19., 22., 43., 50.]
+
+c, s = blas.zrotg(complex(1, 1), complex(0, 0))
+assert abs(c - 1) < 1e-12 and s == 0
+xr, yr = blas.csrot(
+    np.array([1 + 2j], np.complex64),
+    np.array([3 + 4j], np.complex64),
+    0.0,
+    1.0,
+)
+assert xr[0] == 3 + 4j and yr[0] == -1 - 2j
+```
+"""
+
+from pytest_pyodide import run_in_pyodide
+
+
+@run_in_pyodide(packages=["libblis"])
+def test_blis_blas_levels(selenium):
+    import ctypes
+    from ctypes import POINTER, c_double, c_float, c_int
+    from ctypes.util import find_library
+
+    lib = ctypes.CDLL(find_library("blis") or "libblis.so")
+    dp = POINTER(c_double)
+    fp = POINTER(c_float)
+
+    def darr(values):
+        return (c_double * len(values))(*values)
+
+    def farr(values):
+        return (c_float * len(values))(*values)
+
+    def close(got, want, tol=1e-9):
+        assert abs(got - want) <= tol, f"got {got!r} want {want!r}"
+
+    # CBLAS enum values
+    # For reference https://www.cs.ubc.ca/~mpf/bcls/cblas_8h.html
+    ROW_MAJOR = 101
+    NO_TRANS = 111
+
+    # level 1
+    lib.cblas_ddot.restype = c_double
+    lib.cblas_ddot.argtypes = [c_int, dp, c_int, dp, c_int]
+    close(lib.cblas_ddot(4, darr([1, 2, 3, 4]), 1, darr([5, 6, 7, 8]), 1), 70.0)
+
+    lib.cblas_dnrm2.restype = c_double
+    lib.cblas_dnrm2.argtypes = [c_int, dp, c_int]
+    close(lib.cblas_dnrm2(2, darr([3, 4]), 1), 5.0)
+
+    lib.cblas_dasum.restype = c_double
+    lib.cblas_dasum.argtypes = [c_int, dp, c_int]
+    close(lib.cblas_dasum(3, darr([-1, 2, -3]), 1), 6.0)
+
+    lib.cblas_daxpy.argtypes = [c_int, c_double, dp, c_int, dp, c_int]
+    ay = darr([4, 5, 6])
+    lib.cblas_daxpy(3, 2.0, darr([1, 2, 3]), 1, ay, 1)
+    assert [ay[i] for i in range(3)] == [6.0, 9.0, 12.0]
+
+    # level 2: y = A x with A a row major 3 by 3 of 1..9 and x all ones
+    lib.cblas_dgemv.argtypes = [
+        c_int, c_int, c_int, c_int, c_double, dp, c_int, dp, c_int, c_double, dp, c_int
+    ]
+    yv = darr([0, 0, 0])
+    lib.cblas_dgemv(
+        ROW_MAJOR, NO_TRANS, 3, 3, 1.0, darr([1, 2, 3, 4, 5, 6, 7, 8, 9]), 3,
+        darr([1, 1, 1]), 1, 0.0, yv, 1,
+    )
+    assert [yv[i] for i in range(3)] == [6.0, 15.0, 24.0]
+
+    # level 3: C = A B with row major 2 by 2 inputs
+    lib.cblas_dgemm.argtypes = [
+        c_int, c_int, c_int, c_int, c_int, c_int, c_double, dp, c_int, dp, c_int, c_double, dp, c_int
+    ]
+    cm = darr([0, 0, 0, 0])
+    lib.cblas_dgemm(
+        ROW_MAJOR, NO_TRANS, NO_TRANS, 2, 2, 2, 1.0,
+        darr([1, 2, 3, 4]), 2, darr([5, 6, 7, 8]), 2, 0.0, cm, 2,
+    )
+    assert [cm[i] for i in range(4)] == [19.0, 22.0, 43.0, 50.0]
+
+    # zrotg with a = 1 + 1i and b = 0 should leave
+    # r = a, cosine = 1, sine = 0
+    lib.cblas_zrotg.argtypes = [dp, dp, dp, dp]
+    za = darr([1, 1])
+    cc = c_double(0)
+    ss = darr([0, 0])
+    lib.cblas_zrotg(za, darr([0, 0]), ctypes.byref(cc), ss)
+    close(cc.value, 1.0)
+    close(ss[0], 0.0)
+    close(ss[1], 0.0)
+    close(za[0], 1.0)
+    close(za[1], 1.0)
+
+    # csrot
+    lib.cblas_csrot.argtypes = [c_int, fp, c_int, fp, c_int, c_float, c_float]
+    cx = farr([1, 2])
+    cy = farr([3, 4])
+    lib.cblas_csrot(1, cx, 1, cy, 1, 0.0, 1.0)
+    assert [cx[i] for i in range(2)] == [3.0, 4.0]
+    assert [cy[i] for i in range(2)] == [-1.0, -2.0]


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does. -->

This adds a recipe for [BLIS](https://github.com/flame/blis) [v2.1](https://github.com/flame/blis/releases/tag/2.1), a BSD-licensed modern alternative to the traditional BLAS flavours designed to instantiate high-performance dense linear algebra libraries.

The benefit of the library is that it is all C99 and has no Fortran bits, so it compiles cleanly with Emscripten with these changes. It uses architecture-specific microkernels that are written in Assembly for performance reasons. However, obviously, is no kernel for WASM here, so we have no performance benefits of the microkernel architecture, and thus I've compiled it using only a generic target.

I am also experimenting with compiling with SIMD intrinsics locally with the use of the `-msimd128` flag, which works, but I need to benchmark it properly. I'll split that into a separate PR.

I plan to use this recipe further for SciPy's BLAS needs. This is not the final state the recipe will be in, as it needs some further changes (which I've intentionally not included here). 

See #604
xref flame/blis#491
from https://github.com/agriyakhetarpal/blis/pull/1
from https://github.com/agriyakhetarpal/blis/pull/2
See also https://github.com/flame/blis/issues/916 and https://github.com/flame/blis/pull/926

## Type of change

- [ ] Adding a new package
- [ ] Updating an existing package
- [ ] Bug fix
- [x] Other (please describe): Adding a new library, to be later used with consuming packages

---

> [!NOTE]
> **Considering adding a new package?**
>
> With the acceptance of [PEP 783](https://peps.python.org/pep-0783/), package maintainers can now
> build and publish Pyodide-compatible wheels (`pyemscripten` platform) directly to PyPI from their
> own repositories. This is the preferred approach going forward.
>
> Instead of adding a recipe here, we encourage you to:
> 1. Contact the package maintainers and ask them to build Emscripten/Pyodide wheels in their CI
> 2. Refer them to the [Pyodide documentation on building packages](https://pyodide-build.readthedocs.io/en/latest/)
>    and [cibuildwheel's Pyodide support](https://cibuildwheel.pypa.io/en/stable/options/#platform)
>
> We still accept new recipes, but only when it is not possible to build the package upstream.
