### PR TITLE
Enable WASM SIMD intrinsics for BLIS

### DIFF
--- a/packages/libblis/meta.yaml
+++ b/packages/libblis/meta.yaml
@@ -36,6 +36,10 @@ build:
         -o dist/libblis.so
 
     cp dist/libblis.so ${WASM_LIBRARY_DIR}/lib/libblis.so
+requirements:
+  # only for the tests
+  host:
+    - numpy
 about:
   home: https://github.com/flame/blis
   license: BSD-3-Clause

--- a/packages/libblis/patches/0001-Compile-BLIS-to-WebAssembly.patch
+++ b/packages/libblis/patches/0001-Compile-BLIS-to-WebAssembly.patch
@@ -235,7 +235,7 @@ index 00000000..27020ccb
 +
 +# Flags specific to optimized kernels.
 +CKOPTFLAGS     := $(COPTFLAGS) -O3
-+CKVECFLAGS     :=
++CKVECFLAGS     := -msimd128
 +
 +# Flags specific to reference kernels.
 +CROPTFLAGS     := $(CKOPTFLAGS)

--- a/packages/libblis/test_libblis.py
+++ b/packages/libblis/test_libblis.py
@@ -1,129 +1,157 @@
 """
 Functional tests for libblis.
 
-We exercise one routine from each BLAS level, and plus the complex Givens
-rotation wrappers added in patch 0002.
+We exercise one routine from each BLAS level, plus the complex Givens rotation
+wrappers added in patch 0002.
 
-The expected values were computed with a native version of SciPy. In order
-to reproduce the reference numbers, run the snippet below
+The expected values can be computed with SciPy against a native BLAS. In order
+to reproduce the reference numbers, run the snippet below:
 
 ```
 import numpy as np
 from scipy.linalg import blas
 
-x = np.array([1., 2., 3., 4.])
-y = np.array([5., 6., 7., 8.])
-assert blas.ddot(x, y) == 70.0
-assert blas.dnrm2(np.array([3., 4.])) == 5.0
-assert blas.dasum(np.array([-1., 2., -3.])) == 6.0
-assert list(
-    blas.daxpy(np.array([1., 2., 3.]),
-    np.array([4., 5., 6.]), a=2.0),
-) == [6., 9., 12.]
+rng = np.random.RandomState(42)
 
-A = np.arange(1, 10, dtype=float).reshape(3, 3)
-assert list(A @ np.ones(3)) == [6., 15., 24.]
+# definitions
+x = rng.uniform(-1, 1, 8)
+y = rng.uniform(-1, 1, 8)
+alpha = rng.uniform(-1, 1)
+A = rng.uniform(-1, 1, (6, 5))
+xv = rng.uniform(-1, 1, 5)
+Am = rng.uniform(-1, 1, (4, 5))
+Bm = rng.uniform(-1, 1, (5, 3))
+za = complex(rng.uniform(-1, 1), rng.uniform(-1, 1))
+zb = complex(rng.uniform(-1, 1), rng.uniform(-1, 1))
+cx = (rng.uniform(-1, 1, 4) + 1j * rng.uniform(-1, 1, 4)).astype(np.complex64)
+cy = (rng.uniform(-1, 1, 4) + 1j * rng.uniform(-1, 1, 4)).astype(np.complex64)
+rc = rng.uniform(-1, 1)
+rs = rng.uniform(-1, 1)
 
-Am = np.array([[1., 2.], [3., 4.]])
-Bm = np.array([[5., 6.], [7., 8.]])
-assert list((Am @ Bm).ravel()) == [19., 22., 43., 50.]
-
-c, s = blas.zrotg(complex(1, 1), complex(0, 0))
-assert abs(c - 1) < 1e-12 and s == 0
-xr, yr = blas.csrot(
-    np.array([1 + 2j], np.complex64),
-    np.array([3 + 4j], np.complex64),
-    0.0,
-    1.0,
-)
-assert xr[0] == 3 + 4j and yr[0] == -1 - 2j
+# tests
+assert np.isclose(blas.ddot(x, y), x @ y)
+assert np.isclose(blas.dnrm2(x), np.linalg.norm(x))
+assert np.isclose(blas.dasum(x), np.abs(x).sum())
+assert np.allclose(blas.daxpy(x, y.copy(), a=alpha), alpha * x + y)
+assert np.allclose(blas.dgemv(1.0, A, xv), A @ xv)
+assert np.allclose(blas.dgemm(1.0, Am, Bm), Am @ Bm)
+# zrotg builds a rotation [[c, s], [-conj(s), c]] that sends [za, zb] to [r, 0].
+c, s = blas.zrotg(za, zb)
+c = c.real
+assert np.isclose(c * c + abs(s) ** 2, 1.0)
+assert np.isclose(-np.conj(s) * za + c * zb, 0.0, atol=1e-12)
+# csrot applies a real rotation to a pair of complex vectors.
+xr, yr = blas.csrot(cx, cy, rc, rs)
+assert np.allclose(xr, rc * cx + rs * cy, atol=1e-6)
+assert np.allclose(yr, rc * cy - rs * cx, atol=1e-6)
 ```
+
 """
 
 from pytest_pyodide import run_in_pyodide
 
 
-@run_in_pyodide(packages=["libblis"])
+@run_in_pyodide(packages=["libblis", "numpy"])
 def test_blis_blas_levels(selenium):
     import ctypes
     from ctypes import POINTER, c_double, c_float, c_int
     from ctypes.util import find_library
 
+    import numpy as np
+
     lib = ctypes.CDLL(find_library("blis") or "libblis.so")
     dp = POINTER(c_double)
     fp = POINTER(c_float)
 
-    def darr(values):
-        return (c_double * len(values))(*values)
+    def f64(a):
+        return np.ascontiguousarray(a, dtype=np.float64)
 
-    def farr(values):
-        return (c_float * len(values))(*values)
+    def c64(a):
+        return np.ascontiguousarray(a, dtype=np.complex64)
 
-    def close(got, want, tol=1e-9):
-        assert abs(got - want) <= tol, f"got {got!r} want {want!r}"
+    def dptr(a):
+        return a.ctypes.data_as(dp)
+
+    def fptr(a):
+        return a.ctypes.data_as(fp)
 
     # CBLAS enum values
     # For reference https://www.cs.ubc.ca/~mpf/bcls/cblas_8h.html
     ROW_MAJOR = 101
     NO_TRANS = 111
 
+    rng = np.random.RandomState(42)
+    x = f64(rng.uniform(-1, 1, 8))
+    y = f64(rng.uniform(-1, 1, 8))
+    alpha = float(rng.uniform(-1, 1))
+    A = f64(rng.uniform(-1, 1, (6, 5)))
+    xv = f64(rng.uniform(-1, 1, 5))
+    Am = f64(rng.uniform(-1, 1, (4, 5)))
+    Bm = f64(rng.uniform(-1, 1, (5, 3)))
+    za_val = complex(rng.uniform(-1, 1), rng.uniform(-1, 1))
+    zb_val = complex(rng.uniform(-1, 1), rng.uniform(-1, 1))
+    cx = c64(rng.uniform(-1, 1, 4) + 1j * rng.uniform(-1, 1, 4))
+    cy = c64(rng.uniform(-1, 1, 4) + 1j * rng.uniform(-1, 1, 4))
+    rot_c = float(rng.uniform(-1, 1))
+    rot_s = float(rng.uniform(-1, 1))
+
     # level 1
     lib.cblas_ddot.restype = c_double
     lib.cblas_ddot.argtypes = [c_int, dp, c_int, dp, c_int]
-    close(lib.cblas_ddot(4, darr([1, 2, 3, 4]), 1, darr([5, 6, 7, 8]), 1), 70.0)
+    assert np.isclose(lib.cblas_ddot(x.size, dptr(x), 1, dptr(y), 1), x @ y)
 
     lib.cblas_dnrm2.restype = c_double
     lib.cblas_dnrm2.argtypes = [c_int, dp, c_int]
-    close(lib.cblas_dnrm2(2, darr([3, 4]), 1), 5.0)
+    assert np.isclose(lib.cblas_dnrm2(x.size, dptr(x), 1), np.linalg.norm(x))
 
     lib.cblas_dasum.restype = c_double
     lib.cblas_dasum.argtypes = [c_int, dp, c_int]
-    close(lib.cblas_dasum(3, darr([-1, 2, -3]), 1), 6.0)
+    assert np.isclose(lib.cblas_dasum(x.size, dptr(x), 1), np.abs(x).sum())
 
     lib.cblas_daxpy.argtypes = [c_int, c_double, dp, c_int, dp, c_int]
-    ay = darr([4, 5, 6])
-    lib.cblas_daxpy(3, 2.0, darr([1, 2, 3]), 1, ay, 1)
-    assert [ay[i] for i in range(3)] == [6.0, 9.0, 12.0]
+    yb = y.copy()
+    lib.cblas_daxpy(x.size, alpha, dptr(x), 1, dptr(yb), 1)
+    assert np.allclose(yb, alpha * x + y)
 
-    # level 2: y = A x with A a row major 3 by 3 of 1..9 and x all ones
+    # level 2: y = A x
     lib.cblas_dgemv.argtypes = [
         c_int, c_int, c_int, c_int, c_double, dp, c_int, dp, c_int, c_double, dp, c_int
     ]
-    yv = darr([0, 0, 0])
-    lib.cblas_dgemv(
-        ROW_MAJOR, NO_TRANS, 3, 3, 1.0, darr([1, 2, 3, 4, 5, 6, 7, 8, 9]), 3,
-        darr([1, 1, 1]), 1, 0.0, yv, 1,
-    )
-    assert [yv[i] for i in range(3)] == [6.0, 15.0, 24.0]
+    m, n = A.shape
+    yv = np.zeros(m, dtype=np.float64)
+    lib.cblas_dgemv(ROW_MAJOR, NO_TRANS, m, n, 1.0, dptr(A), n, dptr(xv), 1, 0.0, dptr(yv), 1)
+    assert np.allclose(yv, A @ xv)
 
-    # level 3: C = A B with row major 2 by 2 inputs
+    # level 3: C = A B
     lib.cblas_dgemm.argtypes = [
         c_int, c_int, c_int, c_int, c_int, c_int, c_double, dp, c_int, dp, c_int, c_double, dp, c_int
     ]
-    cm = darr([0, 0, 0, 0])
-    lib.cblas_dgemm(
-        ROW_MAJOR, NO_TRANS, NO_TRANS, 2, 2, 2, 1.0,
-        darr([1, 2, 3, 4]), 2, darr([5, 6, 7, 8]), 2, 0.0, cm, 2,
-    )
-    assert [cm[i] for i in range(4)] == [19.0, 22.0, 43.0, 50.0]
+    mm, kk = Am.shape
+    nn = Bm.shape[1]
+    cm = np.zeros((mm, nn), dtype=np.float64)
+    lib.cblas_dgemm(ROW_MAJOR, NO_TRANS, NO_TRANS, mm, nn, kk, 1.0,
+                    dptr(Am), kk, dptr(Bm), nn, 0.0, dptr(cm), nn)
+    assert np.allclose(cm, Am @ Bm)
 
-    # zrotg with a = 1 + 1i and b = 0 should leave
-    # r = a, cosine = 1, sine = 0
+    # zrotg. check that the rotation [[c, s], [-conj(s), c]] sends
+    # [za, zb] to [r, 0], so the test is independent of the sign
+    # convention for c and s.
     lib.cblas_zrotg.argtypes = [dp, dp, dp, dp]
-    za = darr([1, 1])
-    cc = c_double(0)
-    ss = darr([0, 0])
-    lib.cblas_zrotg(za, darr([0, 0]), ctypes.byref(cc), ss)
-    close(cc.value, 1.0)
-    close(ss[0], 0.0)
-    close(ss[1], 0.0)
-    close(za[0], 1.0)
-    close(za[1], 1.0)
+    za = np.array([za_val], dtype=np.complex128)
+    zb = np.array([zb_val], dtype=np.complex128)
+    cc = c_double(0.0)
+    ss = np.zeros(1, dtype=np.complex128)
+    lib.cblas_zrotg(dptr(za), dptr(zb), ctypes.byref(cc), dptr(ss))
+    c = cc.value
+    s = ss[0]
+    assert np.isclose(c * c + abs(s) ** 2, 1.0)
+    assert np.isclose(-np.conj(s) * za_val + c * zb_val, 0.0, atol=1e-12)
+    assert np.isclose(za[0], c * za_val + s * zb_val)
 
-    # csrot
+    # csrot sends (x, y) to (cx + sy, cy - sx)
     lib.cblas_csrot.argtypes = [c_int, fp, c_int, fp, c_int, c_float, c_float]
-    cx = farr([1, 2])
-    cy = farr([3, 4])
-    lib.cblas_csrot(1, cx, 1, cy, 1, 0.0, 1.0)
-    assert [cx[i] for i in range(2)] == [3.0, 4.0]
-    assert [cy[i] for i in range(2)] == [-1.0, -2.0]
+    cxb = cx.copy()
+    cyb = cy.copy()
+    lib.cblas_csrot(cx.size, fptr(cxb), 1, fptr(cyb), 1, rot_c, rot_s)
+    assert np.allclose(cxb, rot_c * cx + rot_s * cy, atol=1e-6)
+    assert np.allclose(cyb, rot_c * cy - rot_s * cx, atol=1e-6)


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does. -->

This updates the BLIS recipe I added in #609 to use the `-msimd128` vectorisation flag. I was able to verify that this increases the library size by 11% and provides a reasonable speedup. Since wasm32 has no hand-written microkernels, this lets Emscripten autovectorise the generic reference kernels.

xref #604

This is the script I used to benchmark, which is a `dgemm` of order 512:

```c
#include <stdio.h>
#include <stdlib.h>
#include "cblas.h"

int main(int argc, char **argv)
{
    int n = argc > 1 ? atoi(argv[1]) : 512;
    int reps = argc > 2 ? atoi(argv[2]) : 60;

    double *A = malloc((size_t)n * n * sizeof(double));
    double *B = malloc((size_t)n * n * sizeof(double));
    double *C = malloc((size_t)n * n * sizeof(double));
    if (!A || !B || !C) {
        fprintf(stderr, "allocation failed for order %d\n", n);
        return 2;
    }

    for (int i = 0; i < n * n; i++) {
        A[i] = (double)((i % 7) - 3) * 0.5;
        B[i] = (double)((i % 5) - 2) * 0.25;
        C[i] = 0.0;
    }

    for (int r = 0; r < reps; r++) {
        cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans, n, n, n,
                    1.0, A, n, B, n, 1.0, C, n);
    }

    double checksum = 0.0;
    for (int i = 0; i < n * n; i++) {
        checksum += C[i];
    }
    printf("order=%d reps=%d checksum=%.6e\n", n, reps, checksum);

    free(A);
    free(B);
    free(C);
    return 0;
}
```

Here are the results with `hyperfine` when running with Node.js after compiling:

```
Benchmark 1: baseline
  Time (mean ± σ):      1.475 s ±  0.105 s    [User: 1.413 s, System: 0.030 s]
  Range (min … max):    1.388 s …  1.740 s    10 runs
 
Benchmark 2: simd
  Time (mean ± σ):     944.3 ms ± 156.3 ms    [User: 910.8 ms, System: 16.7 ms]
  Range (min … max):   867.0 ms … 1384.9 ms    10 runs
```

i.e., roughly 1.56x faster than the baseline:

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `baseline` | 1.475 ± 0.105 | 1.388 | 1.740 | 1.56 ± 0.28 |
| `msimd128` | 0.944 ± 0.156 | 0.867 | 1.385 | 1.00 |

Size comparison:

Metric | Baseline | `-msimd128` | Increase |
-- | -- | -- | -- |
raw object file | 1,080,312 B (1.030 MiB) | 1,200,501 B (1.145 MiB) | +120,189 B (+11.1%) |
gzipped at level 9 | 238,581 B (233 KiB) | 265,539 B (259 KiB) | +26,958 B (+11.3%) |


Since the tests were a bit too rudimentary and relied on handpicked values, I updated them to use random values, as it is important to verify that the SIMD compilation doesn't introduce any regressions.

## Type of change

- [ ] Adding a new package
- [x] Updating an existing package
- [ ] Bug fix
- [ ] Other (please describe)

---

> [!NOTE]
> **Considering adding a new package?**
>
> With the acceptance of [PEP 783](https://peps.python.org/pep-0783/), package maintainers can now
> build and publish Pyodide-compatible wheels (`pyemscripten` platform) directly to PyPI from their
> own repositories. This is the preferred approach going forward.
>
> Instead of adding a recipe here, we encourage you to:
> 1. Contact the package maintainers and ask them to build Emscripten/Pyodide wheels in their CI
> 2. Refer them to the [Pyodide documentation on building packages](https://pyodide-build.readthedocs.io/en/latest/)
>    and [cibuildwheel's Pyodide support](https://cibuildwheel.pypa.io/en/stable/options/#platform)
>
> We still accept new recipes, but only when it is not possible to build the package upstream.
