### PR TITLE
Update OpenBLAS to 0.3.31

### DIFF
--- a/packages/libopenblas/meta.yaml
+++ b/packages/libopenblas/meta.yaml
@@ -1,13 +1,13 @@
 package:
   name: libopenblas
-  version: 0.3.28
+  version: 0.3.31
   tag:
     - core
     - library
     - shared_library
 source:
-  sha256: f1003466ad074e9b0c8d421a204121100b0751c96fc6fcf3d1456bd12f8a00a1
-  url: https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.28/OpenBLAS-0.3.28.tar.gz
+  sha256: 6dd2a63ac9d32643b7cc636eab57bf4e57d0ed1fff926dfbc5d3d97f2d2be3a6
+  url: https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.31/OpenBLAS-0.3.31.tar.gz
   patches:
     - patches/0001-Add-Wno-return-type-flag.patch
     - patches/0002-Align-xerbla_array-signature-with-scipy-expectation.patch

--- a/packages/libopenblas/meta.yaml
+++ b/packages/libopenblas/meta.yaml
@@ -26,6 +26,7 @@ build:
     sed -ri 's/void(\s+)(C?NAME)/int\1\2/g' interface/*.c
     sed -ri 's/((extern)?.+) void ([a-z0-9]+_)/\1\2 int \3/g' lapack-netlib/SRC/*.c \
         lapack-netlib/SRC/DEPRECATED/*.c
+    sed -ri 's/^void (LAED4|LACPY|LASET)\(/int \1(/g' lapack/laed3/*.c
     # For some functions (mostly handling complex I think) f2c actually
     # generate a function that returns void so I need to revert the void to int
     # change the previous line does.

--- a/packages/libopenblas/patches/0003-Skip-linktest.patch
+++ b/packages/libopenblas/patches/0003-Skip-linktest.patch
@@ -11,13 +11,13 @@ diff --git a/exports/Makefile b/exports/Makefile
 index 7682f851d..86b2cd2f4 100644
 --- a/exports/Makefile
 +++ b/exports/Makefile
-@@ -184,24 +184,24 @@ ifeq ($(F_COMPILER), INTEL)
+@@ -199,24 +199,24 @@ ifeq ($(F_COMPILER), INTEL)
  	$(FC) $(FFLAGS) $(LDFLAGS) -shared -o ../$(LIBSONAME) \
  	-Wl,--whole-archive $< -Wl,--no-whole-archive \
  	-Wl,-soname,$(INTERNALNAME) $(EXTRALIB)
 -	$(CC) $(CFLAGS) $(LDFLAGS) -w -o linktest linktest.c ../$(LIBSONAME) $(FEXTRALIB) && echo OK.
 +	echo OK.
- else ifeq ($(F_COMPILER), FLANG)
+ else ifeq ($(F_COMPILER), $(filter $(F_COMPILER),FLANG FLANGNEW))
  	$(FC) $(FFLAGS) $(LDFLAGS) -shared -o ../$(LIBSONAME) \
  	-Wl,--whole-archive $< -Wl,--no-whole-archive \
  	-Wl,-soname,$(INTERNALNAME) $(EXTRALIB)
@@ -40,7 +40,7 @@ index 7682f851d..86b2cd2f4 100644
  endif
  endif
  	rm -f linktest
-@@ -223,7 +223,7 @@ endif
+@@ -238,7 +238,7 @@ endif
  	$(CC) $(CFLAGS) $(LDFLAGS)  -shared -o ../$(LIBSONAME) \
  	-Wl,--whole-archive $< -Wl,--no-whole-archive \
  	$(FEXTRALIB) $(EXTRALIB)
@@ -49,7 +49,7 @@ index 7682f851d..86b2cd2f4 100644
  	rm -f linktest
  
  endif
-@@ -241,7 +241,7 @@ ifeq ($(OSNAME), SunOS)
+@@ -256,7 +256,7 @@ ifeq ($(OSNAME), SunOS)
  so : ../$(LIBSONAME)
  	$(CC) $(CFLAGS) $(LDFLAGS)  -shared -o ../$(LIBSONAME) \
  	-Wl,--whole-archive ../$(LIBNAME) -Wl,--no-whole-archive $(EXTRALIB)
@@ -58,18 +58,11 @@ index 7682f851d..86b2cd2f4 100644
  	rm -f linktest
  
  endif
-@@ -283,9 +283,8 @@ objcopy.def : $(GENSYM) ../Makefile.system ../getarch.c
- objconv.def : $(GENSYM) ../Makefile.system ../getarch.c
- 	./$(GENSYM) objconv $(ARCH) "$(BU)" $(EXPRECISION) $(NO_CBLAS)  $(NO_LAPACK) $(NO_LAPACKE) $(NEED2UNDERSCORES) $(ONLY_CBLAS) "$(SYMBOLPREFIX)" "$(SYMBOLSUFFIX)" $(BUILD_LAPACK_DEPRECATED) $(BUILD_BFLOAT16) $(BUILD_SINGLE) $(BUILD_DOUBLE) $(BUILD_COMPLEX) $(BUILD_COMPLEX16) > $(@F)
- 
+@@ -315,3 +315,2 @@
 -test : linktest.c
 -	$(CC) $(CFLAGS) $(LDFLAGS) -w -o linktest linktest.c ../$(LIBSONAME) -lm && echo OK.
 -	rm -f linktest
 +test :
 +	echo OK.
- 
- linktest.c : $(GENSYM) ../Makefile.system ../getarch.c
- 	./$(GENSYM) linktest  $(ARCH) "$(BU)" $(EXPRECISION) $(NO_CBLAS) $(NO_LAPACK) $(NO_LAPACKE) $(NEED2UNDERSCORES) $(ONLY_CBLAS) "$(SYMBOLPREFIX)" "$(SYMBOLSUFFIX)" $(BUILD_LAPACK_DEPRECATED) $(BUILD_BFLOAT16) $(BUILD_SINGLE) $(BUILD_DOUBLE) $(BUILD_COMPLEX) $(BUILD_COMPLEX16) > linktest.c
 -- 
 2.34.1
-


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does. -->

This updates the `libopenblas` recipe from OpenBLAS 0.3.28 to 0.3.31, matching the OpenBLAS line currently used by upstream SciPy. See #604. We plan to update to OpenBLAS 0.3.32/0.3.33 once upstream SciPy starts using those versions in a released version.

## Type of change

- [ ] Adding a new package
- [x] Updating an existing package
- [ ] Bug fix
- [ ] Other (please describe)

---

> [!NOTE]
> **Considering adding a new package?**
>
> With the acceptance of [PEP 783](https://peps.python.org/pep-0783/), package maintainers can now
> build and publish Pyodide-compatible wheels (`pyemscripten` platform) directly to PyPI from their
> own repositories. This is the preferred approach going forward.
>
> Instead of adding a recipe here, we encourage you to:
> 1. Contact the package maintainers and ask them to build Emscripten/Pyodide wheels in their CI
> 2. Refer them to the [Pyodide documentation on building packages](https://pyodide-build.readthedocs.io/en/latest/)
>    and [cibuildwheel's Pyodide support](https://cibuildwheel.pypa.io/en/stable/options/#platform)
>
> We still accept new recipes, but only when it is not possible to build the package upstream.
