### PR TITLE
upgreade to version 14, then version 15

### DIFF
--- a/packages/highspy/meta.yaml
+++ b/packages/highspy/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: highspy
-  version: 1.13.1
+  version: 1.14.0
   top-level:
     - highspy
 source:
-  url: https://files.pythonhosted.org/packages/source/h/highspy/highspy-1.13.1.tar.gz
+  url: https://files.pythonhosted.org/packages/source/h/highspy/highspy-1.14.0.tar.gz
   sha256: 7888873501c6ca3e0fa19fee960c8b3cb1c64132c5a9b514903cc7e259b5b0c7
 requirements:
   run:


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does. -->

## Type of change

- [ ] Adding a new package
- [X] Updating an existing package
- [ ] Bug fix
- [ ] Other (please describe)

---

> [!NOTE]
> **Considering adding a new package?**
>
> With the acceptance of [PEP 783](https://peps.python.org/pep-0783/), package maintainers can now
> build and publish Pyodide-compatible wheels (`pyemscripten` platform) directly to PyPI from their
> own repositories. This is the preferred approach going forward.
>
> Instead of adding a recipe here, we encourage you to:
> 1. Contact the package maintainers and ask them to build Emscripten/Pyodide wheels in their CI
> 2. Refer them to the [Pyodide documentation on building packages](https://pyodide-build.readthedocs.io/en/latest/)
>    and [cibuildwheel's Pyodide support](https://cibuildwheel.pypa.io/en/stable/options/#platform)
>
> We still accept new recipes, but only when it is not possible to build the package upstream.

Upgrading highspy to v14 and then version 15 