### PR TITLE
Add working ONNX 1.15 recipe

### DIFF
--- a/packages/onnx/meta.yaml
+++ b/packages/onnx/meta.yaml
@@ -1,0 +1,51 @@
+package:
+  name: onnx
+  version: 1.15.0
+  top-level:
+    - onnx
+
+source:
+  url: https://files.pythonhosted.org/packages/source/o/onnx/onnx-1.15.0.tar.gz
+  sha256: b18461a7d38f286618ca2a6e78062a2a9c634ce498e631e708a8041b00094825
+  patches:
+    - patches/0001-use-host-protoc.patch
+    - patches/0002-remove-unsupported-linker-flag.patch
+
+build:
+  script: |
+    protoc_dir="${PKGDIR}/.protoc"
+    if [ ! -x "${protoc_dir}/bin/protoc" ]; then
+      mkdir -p "${protoc_dir}"
+      curl --fail --location --silent --show-error \
+        "https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protoc-22.3-linux-x86_64.zip" \
+        --output "${protoc_dir}/protoc.zip"
+      echo "0f8070d762eb8a2f5a13a47713a553f989f9d9b556e7e3ebfa2bd6464e2ecaeb  ${protoc_dir}/protoc.zip" \
+        | sha256sum --check
+      unzip -q -o "${protoc_dir}/protoc.zip" -d "${protoc_dir}"
+    fi
+    export PROTOC="${protoc_dir}/bin/protoc"
+    export CMAKE_ARGS="${CMAKE_ARGS:-} -DPYTHON_INCLUDE_DIR=${PYTHONINCLUDE} -DPYTHON_INCLUDE_DIRS=${PYTHONINCLUDE} -DPYTHON_LIBRARIES=dummy"
+  cflags: "-DGOOGLE_PROTOBUF_NO_THREAD_SAFETY"
+  post: |
+    rm -rf onnx/backend/test
+
+requirements:
+  run:
+    - numpy
+    - protobuf
+
+test:
+  imports:
+    - onnx
+    - onnx.checker
+    - onnx.helper
+
+about:
+  home: https://onnx.ai/
+  PyPI: https://pypi.org/project/onnx
+  summary: Open Neural Network Exchange
+  license: Apache-2.0
+
+extra:
+  recipe-maintainers:
+    - metalmancode

--- a/packages/onnx/patches/0001-use-host-protoc.patch
+++ b/packages/onnx/patches/0001-use-host-protoc.patch
@@ -1,0 +1,15 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -262,7 +262,11 @@
+     set(protobuf_BUILD_TESTS OFF CACHE BOOL "Build protobuf tests" FORCE)
+     message(STATUS "Download and build Protobuf from ${ProtobufURL}")
+     FetchContent_MakeAvailable(Protobuf Abseil)
+-    set(ONNX_PROTOC_EXECUTABLE $<TARGET_FILE:protobuf::protoc>)
++    if(NOT DEFINED ENV{PROTOC} OR "$ENV{PROTOC}" STREQUAL "")
++      message(FATAL_ERROR
++              "PROTOC must point to a host-native protoc 22.3 binary")
++    endif()
++    set(ONNX_PROTOC_EXECUTABLE "$ENV{PROTOC}")
+     set(Protobuf_VERSION "4.22.3")
+     # Change back the BUILD_SHARED_LIBS to control the onnx project.
+

--- a/packages/onnx/patches/0002-remove-unsupported-linker-flag.patch
+++ b/packages/onnx/patches/0002-remove-unsupported-linker-flag.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -587,8 +587,6 @@
+     target_link_libraries(onnx_cpp2py_export
+                           PRIVATE "-Wl,--whole-archive" $<TARGET_FILE:onnx>
+                                   "-Wl,--no-whole-archive")
+-    set_target_properties(onnx_cpp2py_export
+-                          PROPERTIES LINK_FLAGS "-Wl,--exclude-libs,ALL")
+   endif()
+ 
+   target_link_libraries(onnx_cpp2py_export PRIVATE onnx)

--- a/packages/onnx/test_onnx.py
+++ b/packages/onnx/test_onnx.py
@@ -1,0 +1,29 @@
+from pytest_pyodide import run_in_pyodide
+
+
+@run_in_pyodide(packages=["onnx"])
+def test_onnx_create_check_and_serialize(selenium):
+    import onnx
+    from onnx import TensorProto, checker, helper
+
+    node = helper.make_node("Relu", ["input"], ["output"])
+    graph = helper.make_graph(
+        [node],
+        "browser_graph",
+        [helper.make_tensor_value_info("input", TensorProto.FLOAT, [1, 2])],
+        [helper.make_tensor_value_info("output", TensorProto.FLOAT, [1, 2])],
+    )
+    model = helper.make_model(
+        graph,
+        producer_name="pyodide-recipes",
+        opset_imports=[helper.make_opsetid("", 18)],
+    )
+
+    checker.check_model(model)
+    payload = model.SerializeToString()
+    restored = onnx.load_model_from_string(payload)
+    checker.check_model(restored)
+
+    assert payload
+    assert restored.graph.name == "browser_graph"
+    assert restored.graph.node[0].op_type == "Relu"


### PR DESCRIPTION
## Summary

Add an experimental ONNX 1.15.0 recipe with a reproducible, working WebAssembly build.

Closes #216 with a version set that has been built from the recipe, structurally verified, and exercised through a full browser conversion path.

## Cross-compilation fixes

- use a host-native `protoc` 22.3 while compiling the Protobuf runtime for WebAssembly;
- pass the target Python include directories from `PYTHONINCLUDE` to CMake;
- remove the ELF-only `--exclude-libs` linker option unsupported by `wasm-ld`; and
- disable Protobuf thread-safety for the standard single-threaded side-module build.

The host `protoc` archive is pinned by SHA-256.

## Validation

The independently reproduced Pyodide 0.29.4 / Python 3.13 build produced a 1.7 MB wheel and passed:

1. WebAssembly magic and CPython module-export checks;
2. `import onnx`, `onnx.checker`, and `onnx.helper`;
3. browser-local `scikit-learn` training;
4. conversion with `skl2onnx` 1.19.1;
5. ONNX validation and serialization; and
6. execution with ONNX Runtime Web 1.22.0.

Public recipe and build provenance:
https://github.com/metalmancode/onnx-pyodide

Live end-to-end proof:
https://metalmancode.github.io/onnx-pyodide/demo/

Verified release and wheel:
https://github.com/metalmancode/onnx-pyodide/releases/tag/v0.1.0

Wheel SHA-256:
`2a827f6e2649395743afac49186343ca9221f48a1c67cce300cd019a7f448cd4`

## Current-repository validation

The recipe now builds successfully with the repository's current Python 3.14 / Pyodide toolchain. A targeted fork CI run built the wheel and passed the recipe's runtime test in Chrome, Firefox, and Node:

https://github.com/metalmancode/pyodide-recipes/actions/runs/29262798470

The runtime test creates a small ONNX graph, validates it through the compiled checker, serializes it, loads it back, and validates the restored model.

Related work: #463 targets ONNX 1.20.0 but currently has a failing build. This pull request intentionally starts from the independently reproduced and current-toolchain-validated 1.15.0 baseline rather than claiming unverified 1.20.0 support.

## Provenance

The port and browser proof were created by Gholamreza Rashidi Ardestani (`@metalmancode`) from the browser-local ONNX export work used in [MLDeck](https://mldeck.com/).
