### PR TITLE
Upgrade numpy to v2.4.6

### DIFF
--- a/packages/numpy-tests/meta.yaml
+++ b/packages/numpy-tests/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: numpy-tests
-  version: 2.4.3
+  version: 2.4.6
   tag:
     - min-scipy-stack
 # NOTE: keep in sync with numpy/meta.yaml
 source:
-  path: ../numpy/build/numpy-2.4.3
+  path: ../numpy/build/numpy-2.4.6
 
 build:
   unvendor-tests: false # we do this on our own using Meson's install tags

--- a/packages/numpy/meta.yaml
+++ b/packages/numpy/meta.yaml
@@ -1,15 +1,15 @@
 
 package:
   name: numpy
-  version: 2.4.3
+  version: 2.4.6
   tag:
     - cross-build
     - min-scipy-stack
   top-level:
     - numpy
 source:
-  url: https://files.pythonhosted.org/packages/source/n/numpy/numpy-2.4.3.tar.gz
-  sha256: 483a201202b73495f00dbc83796c6ae63137a9bdade074f7648b3e32613412dd
+  url: https://files.pythonhosted.org/packages/source/n/numpy/numpy-2.4.6.tar.gz
+  sha256: f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda
 
 build:
   unvendor-tests: false # we do this on our own using Meson's install tags


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does. -->

## Type of change

- [ ] Adding a new package
- [x] Updating an existing package
- [ ] Bug fix
- [ ] Other (please describe)

---

> [!NOTE]
> **Considering adding a new package?**
>
> With the acceptance of [PEP 783](https://peps.python.org/pep-0783/), package maintainers can now
> build and publish Pyodide-compatible wheels (`pyemscripten` platform) directly to PyPI from their
> own repositories. This is the preferred approach going forward.
>
> Instead of adding a recipe here, we encourage you to:
> 1. Contact the package maintainers and ask them to build Emscripten/Pyodide wheels in their CI
> 2. Refer them to the [Pyodide documentation on building packages](https://pyodide-build.readthedocs.io/en/latest/)
>    and [cibuildwheel's Pyodide support](https://cibuildwheel.pypa.io/en/stable/options/#platform)
>
> We still accept new recipes, but only when it is not possible to build the package upstream.
