### PR TITLE
Explicitly disable openmp in healpy recipe

### DIFF
--- a/packages/healpy/meta.yaml
+++ b/packages/healpy/meta.yaml
@@ -10,6 +10,7 @@ source:
     - patches/0001-build-no-binaries.patch
     - patches/0002-without-zlib-check-fortran.patch
     - patches/0003-install-path.patch
+    - patches/0004-disable-openmp.patch
 requirements:
   host:
     - libzlib

--- a/packages/healpy/patches/0004-disable-openmp.patch
+++ b/packages/healpy/patches/0004-disable-openmp.patch
@@ -1,0 +1,15 @@
+Emscripten 6 added OpenMP support, so autoconf's AC_OPENMP check now succeeds
+and healpix_cxx's configure appends -fopenmp to CFLAGS/CXXFLAGS. On Emscripten
+`-fopenmp` implies pthreads which is causes a link error.
+
+diff --git a/setup.py b/setup.py
+--- a/setup.py
++++ b/setup.py
+@@ -173,6 +173,7 @@
+                 "--disable-maintainer-mode",
+                 "--without-zlib-check",
+                 "--without-fortran",
++                "--disable-openmp",
+             ]
+ 
+             log.info("%s", " ".join(cmd))


### PR DESCRIPTION
Emscripten 6.0.0 added openmp support but it requires pthreads which fails to link. Explicitly turn it off.