### PR TITLE
CI Run SciPy tests for the "full build" label too

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
           GITHUB_EVENT_PULL_REQUEST_TITLE: ${{ github.event.pull_request.title }}
           GITHUB_EVENT_INPUTS_SCIPY: ${{ github.event.inputs.scipy }}
         # Run if commit_msg contains "[scipy]" or
-        # if the PR has the "scipy" label or
+        # if the PR has the "scipy" label or the "full build" label or
         # if the PR title contains "[scipy]" or if
         # the workflow is triggered manually with the `scipy` input set to true
         run: |
@@ -57,12 +57,14 @@ jobs:
           COMMIT_MSG=$(git log --no-merges -1 --oneline)
           PR_TITLE="${GITHUB_EVENT_PULL_REQUEST_TITLE}"
           SCIPY_LABEL=${{ contains(github.event.pull_request.labels.*.name, 'scipy') }}
+          FULL_BUILD_LABEL=${{ contains(github.event.pull_request.labels.*.name, 'full build') }}
           SCIPY_INPUT="${GITHUB_EVENT_INPUTS_SCIPY}"
           GITHUB_EVENT_NAME="${{ github.event_name }}"
 
           if [[ "$COMMIT_MSG" =~ \[scipy\] ]] || \
              [[ "$PR_TITLE" =~ \[scipy\] ]] || \
              [[ "$SCIPY_LABEL" == "true" ]] || \
+             [[ "$FULL_BUILD_LABEL" == "true" ]] || \
              { [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]] && [[ "$SCIPY_INPUT" == "true" ]]; }
           then
             echo "SciPy tests will run"


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does. -->

Noticed in #639

## Type of change

- [ ] Adding a new package
- [ ] Updating an existing package
- [ ] Bug fix
- [x] Other (please describe)

---

> [!NOTE]
> **Considering adding a new package?**
>
> With the acceptance of [PEP 783](https://peps.python.org/pep-0783/), package maintainers can now
> build and publish Pyodide-compatible wheels (`pyemscripten` platform) directly to PyPI from their
> own repositories. This is the preferred approach going forward.
>
> Instead of adding a recipe here, we encourage you to:
> 1. Contact the package maintainers and ask them to build Emscripten/Pyodide wheels in their CI
> 2. Refer them to the [Pyodide documentation on building packages](https://pyodide-build.readthedocs.io/en/latest/)
>    and [cibuildwheel's Pyodide support](https://cibuildwheel.pypa.io/en/stable/options/#platform)
>
> We still accept new recipes, but only when it is not possible to build the package upstream.
