### PR TITLE
Update libxml to 2.14.6

### DIFF
--- a/packages/libxml/meta.yaml
+++ b/packages/libxml/meta.yaml
@@ -1,12 +1,12 @@
 package:
   name: libxml
-  version: 2.9.10
+  version: 2.14.6
   tag:
     - library
     - static_library
 source:
-  sha256: aafee193ffb8fe0c82d4afef6ef91972cbaf5feea100edc2f262750611b4be1f
-  url: http://xmlsoft.org/sources/libxml2-2.9.10.tar.gz
+  sha256: 7ce458a0affeb83f0b55f1f4f9e0e55735dbfc1a9de124ee86fb4a66b597203a
+  url: https://download.gnome.org/sources/libxml2/2.14/libxml2-2.14.6.tar.xz
 
 requirements:
   host:
@@ -28,5 +28,5 @@ build:
     emmake make -j ${PYODIDE_JOBS:-3}
     emmake make install
 about:
-  home: https://github.com/GNOME/libxml2
+  home: https://gitlab.gnome.org/GNOME/libxml2
   license: MIT

--- a/packages/libxml/meta.yaml
+++ b/packages/libxml/meta.yaml
@@ -21,8 +21,8 @@ build:
         --disable-dependency-tracking \
         --disable-shared \
         --without-python \
-        --with-iconv="${WASM_LIBRARY_DIR}/lib" \
-        --with-zlib="${WASM_LIBRARY_DIR}/lib" \
+        --with-iconv="${WASM_LIBRARY_DIR}" \
+        --with-zlib="${WASM_LIBRARY_DIR}" \
         --with-lzma="no" \
         --prefix=${WASM_LIBRARY_DIR}
     emmake make -j ${PYODIDE_JOBS:-3}


### PR DESCRIPTION
Package lxml 6.0.2 uses libxml 2.14.6 for binary wheels. Updated to reflect this change. GNOME home page was also updated.

## Description

<!-- Briefly describe what this PR does. -->

## Type of change

- [ ] Adding a new package
- [x] Updating an existing package
- [ ] Bug fix
- [ ] Other (please describe)

---

> [!NOTE]
> **Considering adding a new package?**
>
> With the acceptance of [PEP 783](https://peps.python.org/pep-0783/), package maintainers can now
> build and publish Pyodide-compatible wheels (`pyemscripten` platform) directly to PyPI from their
> own repositories. This is the preferred approach going forward.
>
> Instead of adding a recipe here, we encourage you to:
> 1. Contact the package maintainers and ask them to build Emscripten/Pyodide wheels in their CI
> 2. Refer them to the [Pyodide documentation on building packages](https://pyodide-build.readthedocs.io/en/latest/)
>    and [cibuildwheel's Pyodide support](https://cibuildwheel.pypa.io/en/stable/options/#platform)
>
> We still accept new recipes, but only when it is not possible to build the package upstream.

Hi, [according to lxml changelog](https://lxml.de/6.0/changes-6.0.2.html), version 6.0.2 uses libxml 2.14.6.

I used [the official source](https://download.gnome.org/sources/libxml2/2.14/) for libxml.

I also updated the GNOME git page to GitLab.