### PR TITLE
CI Replace pyodide-actions with selenium manager

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,6 +121,11 @@ jobs:
           mamba env update -n pyodide-env -f environment.yml
         if: steps.conda-cache.outputs.cache-hit != 'true'
 
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+
       # See https://github.com/jlumbroso/free-disk-space/issues/40
       - name: Disable man-db to free up disk space faster
         run: |
@@ -313,8 +318,8 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         test-config: [
-          {runner: selenium, runtime: chrome, runtime-version: 134 },
-          {runner: selenium, runtime: firefox, runtime-version: "136.0" },
+          {runner: selenium, runtime: chrome, runtime-version: stable },
+          {runner: selenium, runtime: firefox, runtime-version: stable },
           {runner: selenium, runtime: node, runtime-version: "24" },
         ]
 
@@ -359,11 +364,11 @@ jobs:
           mamba env update -n pyodide-env -f environment.yml
         if: steps.conda-cache.outputs.cache-hit != 'true'
 
-      - uses: pyodide/pyodide-actions/install-browser@012fa537869d343726d01863a34b773fc4d96a14 # v2
+      - name: Set up Node.js
+        if: matrix.test-config.runtime == 'node'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          runner: ${{ matrix.test-config.runner }}
-          browser: ${{ matrix.test-config.runtime }}
-          browser-version: ${{ matrix.test-config.runtime-version }}
+          node-version: ${{ matrix.test-config.runtime-version }}
 
       - name: Download build artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -376,7 +381,20 @@ jobs:
           which python
           echo y | python -m pip install -r requirements.txt
 
+      - name: Install browser and driver
+        if: matrix.test-config.runtime != 'node'
+        run: |
+          tools/install_browser.sh \
+            ${{ matrix.test-config.runtime }} \
+            ${{ matrix.test-config.runtime-version }}
+
       - name: Run tests
+        env:
+          SE_AVOID_STATS: "true"
+          SE_BROWSER_VERSION: ${{ matrix.test-config.runtime-version }}
+          SE_OFFLINE: "true"
+          SE_SKIP_BROWSER_IN_PATH: "true"
+          SE_SKIP_DRIVER_IN_PATH: "true"
         run: |
           pytest -v \
             --dist-dir=./dist/ \
@@ -450,11 +468,10 @@ jobs:
           conda-remove-defaults: true
           channels: conda-forge
 
-      - uses: pyodide/pyodide-actions/install-browser@012fa537869d343726d01863a34b773fc4d96a14 # v2
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          runner: selenium
-          browser: node
-          browser-version: "24"
+          node-version: "24"
 
       - name: Download build artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -522,6 +539,11 @@ jobs:
         run:
           mamba env update -n pyodide-env -f environment.yml
         if: steps.conda-cache.outputs.cache-hit != 'true'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
 
       - name: Download build artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,6 @@ channels:
   - conda-forge
 dependencies:
   - python=3.14.0
-  - nodejs=20
   - ccache
   - f2c
   # swiglpk has compatibility issue with 4.5 or upper

--- a/tools/install_browser.sh
+++ b/tools/install_browser.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -euo pipefail
+
+PYTHON=${PYTHON:-python}
+BROWSER=${1:-}
+BROWSER_VERSION=${2:-stable}
+
+if [[ $# -gt 2 ]] || [[ -n "${BROWSER}" && "${BROWSER}" != "chrome" && "${BROWSER}" != "firefox" ]]; then
+  echo "Usage: $0 [chrome|firefox] [browser-version]" >&2
+  exit 2
+fi
+
+if ! "${PYTHON}" -c "import selenium" >/dev/null 2>&1; then
+  echo "Selenium is required. Install requirements.txt before running this script." >&2
+  exit 1
+fi
+
+if [[ -n "${BROWSER}" ]]; then
+  BROWSERS=("${BROWSER}")
+else
+  BROWSERS=(chrome firefox)
+fi
+
+for browser in "${BROWSERS[@]}"; do
+  "${PYTHON}" - "${browser}" "${BROWSER_VERSION}" <<'PY'
+import sys
+
+from selenium.webdriver.common.selenium_manager import SeleniumManager
+
+browser, browser_version = sys.argv[1:]
+paths = SeleniumManager().binary_paths(
+    [
+        "--browser",
+        browser,
+        "--browser-version",
+        browser_version,
+        "--force-browser-download",
+        "--skip-browser-in-path",
+        "--skip-driver-in-path",
+        "--avoid-stats",
+    ]
+)
+
+print(f"{browser} {browser_version} installed at {paths['browser_path']}")
+print(f"Matching driver installed at {paths['driver_path']}")
+PY
+done


### PR DESCRIPTION
our chrome CI was broken for a while since chrome version mismatched with chrome driver version.

This PR replaces `pyodide-actions` github actions that was installing browsers to selenium manager, which is more maintained. Pyodide dockerfile is also using that.